### PR TITLE
feat(issue-2): unified provider gateway in bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,14 @@
 
 ```
 前端 (Vite + React + Tailwind)  ←→  bridge/server.js (Express :4891)  ←→  Redis / codex.exe / Anthropic API
+                                         └── gateway.js (统一 provider 路由)
+                                               ├── providers/claude.js
+                                               └── providers/codex.js
 ```
 
 - 前端不直连任何 AI API，全部经由 bridge 中转
+- 前端只调用 `src/agents/gatewayAgent.js`，不含任何 provider-specific 逻辑
+- bridge `POST /gateway/stream` 是唯一 AI 请求入口，provider 差异收敛在 `bridge/providers/`
 - `useChatStore` 是唯一状态源，无 Zustand/Redux
 - Redis key: `cat-cafe:conversations`，存全量会话 JSON
 

--- a/bridge/gateway.js
+++ b/bridge/gateway.js
@@ -1,0 +1,43 @@
+/**
+ * Provider Gateway
+ * POST /gateway/stream
+ * body: { provider, messages, model, systemPrompt }
+ * 统一 SSE 输出: { type: 'chunk'|'usage'|'error'|'done', ... }
+ */
+import * as claude from './providers/claude.js'
+import * as codex from './providers/codex.js'
+
+const PROVIDERS = { claudecode: claude, codex }
+
+export function registerGateway(app) {
+  app.post('/gateway/stream', async (req, res) => {
+    const { provider, messages = [], model, systemPrompt } = req.body
+    const adapter = PROVIDERS[provider]
+
+    if (!adapter) {
+      res.status(400).json({ message: `Unknown provider: ${provider}` })
+      return
+    }
+
+    res.setHeader('Content-Type', 'text/event-stream')
+    res.setHeader('Cache-Control', 'no-cache')
+    res.setHeader('Connection', 'keep-alive')
+
+    const ac = new AbortController()
+    res.on('close', () => ac.abort())
+
+    try {
+      for await (const event of adapter.stream({ messages, model, systemPrompt, signal: ac.signal })) {
+        if (ac.signal.aborted) break
+        res.write(`data: ${JSON.stringify(event)}\n\n`)
+        if (event.type === 'done' || event.type === 'error') break
+      }
+    } catch (err) {
+      if (!ac.signal.aborted) {
+        res.write(`data: ${JSON.stringify({ type: 'error', message: err.message })}\n\n`)
+      }
+    }
+
+    if (!ac.signal.aborted) res.end()
+  })
+}

--- a/bridge/gateway.js
+++ b/bridge/gateway.js
@@ -9,8 +9,8 @@ import * as codex from './providers/codex.js'
 
 const PROVIDERS = { claudecode: claude, codex }
 
-export function registerGateway(app) {
-  app.post('/gateway/stream', async (req, res) => {
+export function registerGateway(app, requireLocalToken) {
+  app.post('/gateway/stream', requireLocalToken, async (req, res) => {
     const { provider, messages = [], model, systemPrompt } = req.body
     const adapter = PROVIDERS[provider]
 

--- a/bridge/providers/claude.js
+++ b/bridge/providers/claude.js
@@ -5,8 +5,6 @@
  */
 import Anthropic from '@anthropic-ai/sdk'
 
-const client = new Anthropic({ apiKey: process.env.CLAUDE_API_KEY })
-
 export const id = 'claudecode'
 
 export function isAvailable() {
@@ -18,6 +16,8 @@ export async function* stream({ messages, model = 'claude-sonnet-4-6', systemPro
     yield { type: 'error', message: 'CLAUDE_API_KEY not set in bridge environment' }
     return
   }
+
+  const client = new Anthropic({ apiKey: process.env.CLAUDE_API_KEY })
 
   const params = { model, max_tokens: 8096, messages }
   if (systemPrompt) params.system = systemPrompt

--- a/bridge/providers/claude.js
+++ b/bridge/providers/claude.js
@@ -1,0 +1,43 @@
+/**
+ * Claude provider adapter
+ * 输入: { messages, model, systemPrompt }
+ * 输出: async generator，yield { type, ... }
+ */
+import Anthropic from '@anthropic-ai/sdk'
+
+const client = new Anthropic({ apiKey: process.env.CLAUDE_API_KEY })
+
+export const id = 'claudecode'
+
+export function isAvailable() {
+  return !!process.env.CLAUDE_API_KEY
+}
+
+export async function* stream({ messages, model = 'claude-sonnet-4-6', systemPrompt, signal }) {
+  if (!isAvailable()) {
+    yield { type: 'error', message: 'CLAUDE_API_KEY not set in bridge environment' }
+    return
+  }
+
+  const params = { model, max_tokens: 8096, messages }
+  if (systemPrompt) params.system = systemPrompt
+
+  const anthropicStream = client.messages.stream(params)
+
+  signal?.addEventListener('abort', () => anthropicStream.abort())
+
+  try {
+    for await (const event of anthropicStream) {
+      if (signal?.aborted) break
+      if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+        yield { type: 'chunk', text: event.delta.text }
+      }
+      if (event.type === 'message_delta' && event.usage) {
+        yield { type: 'usage', usage: event.usage }
+      }
+    }
+    if (!signal?.aborted) yield { type: 'done' }
+  } catch (err) {
+    if (!signal?.aborted) yield { type: 'error', message: err.message }
+  }
+}

--- a/bridge/providers/codex.js
+++ b/bridge/providers/codex.js
@@ -1,0 +1,98 @@
+/**
+ * Codex provider adapter
+ * 输入: { messages, model }
+ * 输出: async generator，yield { type, ... }
+ */
+import { spawn } from 'child_process'
+import { existsSync } from 'fs'
+import { EventEmitter } from 'events'
+
+export const id = 'codex'
+
+const CODEX_EXE = process.env.CODEX_EXE_PATH ||
+  'C:\\Users\\Administrator\\AppData\\Roaming\\JetBrains\\WebStorm2024.2\\node\\versions\\23.0.0\\node_modules\\@openai\\codex\\node_modules\\@openai\\codex-win32-x64\\vendor\\x86_64-pc-windows-msvc\\codex\\codex.exe'
+
+export function isAvailable() {
+  return existsSync(CODEX_EXE)
+}
+
+export async function* stream({ messages, model, signal }) {
+  if (!isAvailable()) {
+    yield { type: 'error', message: `codex.exe not found: ${CODEX_EXE}` }
+    return
+  }
+
+  const lastUserIdx = messages.findLastIndex(m => m.role === 'user')
+  const lastUser = messages[lastUserIdx]
+  if (!lastUser) {
+    yield { type: 'error', message: '没有用户消息' }
+    return
+  }
+
+  const historyMessages = messages.slice(0, lastUserIdx)
+  const contextPrefix = historyMessages.length > 0
+    ? historyMessages.map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`).join('\n') + '\n\nUser: '
+    : ''
+  const prompt = contextPrefix + lastUser.content
+
+  const args = ['exec', '--json', '--skip-git-repo-check', '--ephemeral', '--dangerously-bypass-approvals-and-sandbox']
+  if (model) args.push('-m', model)
+  args.push(prompt)
+
+  const child = spawn(CODEX_EXE, args)
+  signal?.addEventListener('abort', () => { if (!child.killed) child.kill() })
+
+  // async queue via EventEmitter
+  const emitter = new EventEmitter()
+  const queue = []
+  let closed = false
+
+  const push = (event) => {
+    queue.push(event)
+    emitter.emit('data')
+  }
+
+  let buffer = ''
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk.toString()
+    const lines = buffer.split('\n')
+    buffer = lines.pop()
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      try {
+        const json = JSON.parse(trimmed)
+        if (json.type === 'item.completed' && json.item?.type === 'agent_message') {
+          push({ type: 'chunk', text: json.item.text })
+        }
+        if (json.type === 'turn.completed' && json.usage) {
+          push({ type: 'usage', usage: json.usage })
+        }
+      } catch { /* 忽略非 JSON 行 */ }
+    }
+  })
+
+  child.stderr.on('data', (chunk) => console.error('[codex stderr]', chunk.toString()))
+
+  child.on('error', (err) => {
+    push({ type: 'error', message: err.message })
+    closed = true
+    emitter.emit('data')
+  })
+
+  child.on('close', () => {
+    if (!signal?.aborted) push({ type: 'done' })
+    closed = true
+    emitter.emit('data')
+  })
+
+  while (true) {
+    if (queue.length > 0) {
+      yield queue.shift()
+    } else if (closed) {
+      break
+    } else {
+      await new Promise(resolve => emitter.once('data', resolve))
+    }
+  }
+}

--- a/bridge/server.js
+++ b/bridge/server.js
@@ -4,6 +4,7 @@ import { spawn } from 'child_process'
 import { existsSync } from 'fs'
 import Redis from 'ioredis'
 import Anthropic from '@anthropic-ai/sdk'
+import { registerGateway } from './gateway.js'
 
 const app = express()
 app.use(cors())
@@ -207,6 +208,8 @@ app.post('/codex/stream', (req, res) => {
     if (!child.killed) child.kill()
   })
 })
+
+registerGateway(app)
 
 app.listen(4891, () => {
   console.log('[bridge] Codex bridge running on http://localhost:4891')

--- a/bridge/server.js
+++ b/bridge/server.js
@@ -2,13 +2,51 @@ import express from 'express'
 import cors from 'cors'
 import { spawn } from 'child_process'
 import { existsSync } from 'fs'
+import { randomBytes } from 'crypto'
 import Redis from 'ioredis'
 import Anthropic from '@anthropic-ai/sdk'
 import { registerGateway } from './gateway.js'
 
+// 启动时生成一次性本地 token，仅限 localhost 客户端获取
+const LOCAL_TOKEN = randomBytes(32).toString('hex')
+
+const ALLOWED_ORIGINS = [
+  'http://localhost:5173',
+  'http://localhost:4173',
+  'http://127.0.0.1:5173',
+  'http://127.0.0.1:4173',
+]
+
 const app = express()
-app.use(cors())
+app.use(cors({
+  origin: (origin, cb) => {
+    // 允许无 origin（curl/本地直连）或白名单内的 localhost origin
+    if (!origin || ALLOWED_ORIGINS.includes(origin)) return cb(null, true)
+    cb(new Error(`CORS: origin ${origin} not allowed`))
+  },
+  credentials: true,
+}))
 app.use(express.json())
+
+// GET /token — 仅限 localhost 获取本地 token（供前端初始化时调用）
+app.get('/token', (req, res) => {
+  const host = req.hostname
+  if (host !== 'localhost' && host !== '127.0.0.1') {
+    res.status(403).json({ message: 'Forbidden' })
+    return
+  }
+  res.json({ token: LOCAL_TOKEN })
+})
+
+// provider 路由鉴权中间件
+function requireLocalToken(req, res, next) {
+  const token = req.headers['x-local-token']
+  if (token !== LOCAL_TOKEN) {
+    res.status(401).json({ message: 'Unauthorized: missing or invalid x-local-token' })
+    return
+  }
+  next()
+}
 
 const redis = new Redis(process.env.REDIS_URL || 'redis://127.0.0.1:6379')
 const CONV_KEY = 'cat-cafe:conversations'
@@ -61,8 +99,8 @@ app.put('/agents', async (req, res) => {
   }
 })
 
-// POST /claude/stream — Claude 流式代理，API Key 只在 bridge 侧读取，upstream 固定不接受客户端传入
-app.post('/claude/stream', async (req, res) => {
+// POST /claude/stream — 旧路由保留向后兼容，已加 token 鉴权
+app.post('/claude/stream', requireLocalToken, async (req, res) => {
   const { messages = [], model, systemPrompt } = req.body
   const apiKey = process.env.CLAUDE_API_KEY
   if (!apiKey) {
@@ -114,12 +152,8 @@ app.post('/claude/stream', async (req, res) => {
 const CODEX_EXE = process.env.CODEX_EXE_PATH ||
   'C:\\Users\\Administrator\\AppData\\Roaming\\JetBrains\\WebStorm2024.2\\node\\versions\\23.0.0\\node_modules\\@openai\\codex\\node_modules\\@openai\\codex-win32-x64\\vendor\\x86_64-pc-windows-msvc\\codex\\codex.exe'
 
-/**
- * POST /codex/stream
- * body: { messages: [{role, content}], model? }
- * 返回 SSE 流，每条 data 为 { text } 或 { usage } 或 { error }
- */
-app.post('/codex/stream', (req, res) => {
+// POST /codex/stream — 旧路由保留向后兼容，已加 token 鉴权
+app.post('/codex/stream', requireLocalToken, (req, res) => {
   const { messages = [], model } = req.body
 
   if (!existsSync(CODEX_EXE)) {
@@ -209,7 +243,7 @@ app.post('/codex/stream', (req, res) => {
   })
 })
 
-registerGateway(app)
+registerGateway(app, requireLocalToken)
 
 app.listen(4891, () => {
   console.log('[bridge] Codex bridge running on http://localhost:4891')

--- a/src/agents/gatewayAgent.js
+++ b/src/agents/gatewayAgent.js
@@ -6,6 +6,20 @@
 
 const BRIDGE = import.meta.env.VITE_CODEX_BRIDGE_URL || 'http://localhost:4891'
 
+// 启动时从 bridge 获取本地 token，后续所有请求携带
+let localToken = null
+async function getToken() {
+  if (localToken) return localToken
+  try {
+    const res = await fetch(`${BRIDGE}/token`)
+    const data = await res.json()
+    localToken = data.token
+  } catch {
+    console.error('[gateway] failed to fetch local token')
+  }
+  return localToken
+}
+
 /**
  * @param {string} provider - 'claudecode' | 'codex'
  * @param {Array} messages - [{role, content}]
@@ -21,12 +35,16 @@ export function streamProvider({ provider, messages, model, systemPrompt, onChun
 
   const run = async () => {
     try {
+      const token = await getToken()
       const body = { provider, messages, model }
       if (systemPrompt) body.systemPrompt = systemPrompt
 
       const res = await fetch(`${BRIDGE}/gateway/stream`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { 'x-local-token': token } : {}),
+        },
         body: JSON.stringify(body),
         signal: controller.signal,
       })

--- a/src/agents/gatewayAgent.js
+++ b/src/agents/gatewayAgent.js
@@ -1,0 +1,79 @@
+/**
+ * Gateway Agent
+ * 前端唯一的 provider 请求入口，通过 bridge /gateway/stream 统一调用
+ * 不包含任何 provider-specific 逻辑
+ */
+
+const BRIDGE = import.meta.env.VITE_CODEX_BRIDGE_URL || 'http://localhost:4891'
+
+/**
+ * @param {string} provider - 'claudecode' | 'codex'
+ * @param {Array} messages - [{role, content}]
+ * @param {string} model
+ * @param {string} systemPrompt
+ * @param {function} onChunk - (text) => void
+ * @param {function} onDone - (fullText, usage) => void
+ * @param {function} onError - (err) => void
+ * @returns {AbortController}
+ */
+export function streamProvider({ provider, messages, model, systemPrompt, onChunk, onDone, onError }) {
+  const controller = new AbortController()
+
+  const run = async () => {
+    try {
+      const body = { provider, messages, model }
+      if (systemPrompt) body.systemPrompt = systemPrompt
+
+      const res = await fetch(`${BRIDGE}/gateway/stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      })
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ message: res.statusText }))
+        throw new Error(err.message || `HTTP ${res.status}`)
+      }
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let fullText = ''
+      let usage = null
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop()
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue
+          const data = line.slice(6).trim()
+          try {
+            const json = JSON.parse(data)
+            if (json.type === 'chunk') {
+              fullText += json.text
+              onChunk?.(json.text)
+            }
+            if (json.type === 'usage') usage = json.usage
+            if (json.type === 'error') throw new Error(json.message)
+            if (json.type === 'done') break
+          } catch (e) {
+            if (e.message !== 'Unexpected end of JSON input') throw e
+          }
+        }
+      }
+
+      onDone?.(fullText, usage)
+    } catch (err) {
+      if (err.name !== 'AbortError') onError?.(err)
+    }
+  }
+
+  run()
+  return controller
+}

--- a/src/store/chatStore.js
+++ b/src/store/chatStore.js
@@ -1,6 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { streamClaudeCode } from '../agents/claudeCodeAgent'
-import { streamCodex } from '../agents/codexAgent'
+import { streamProvider } from '../agents/gatewayAgent'
 
 const newId = () => crypto.randomUUID()
 const newConvId = () => crypto.randomUUID()
@@ -197,9 +196,7 @@ export function useChatStore(agents = []) {
             setSessionStatus(convId, agentId, 'ERROR')
           },
         }
-        const ctrl = cfg.provider === 'codex'
-          ? streamCodex({ messages: history, model: cfg.modelId, ...handlers })
-          : streamClaudeCode({ messages: history, model: cfg.modelId, systemPrompt: cfg.systemPrompt, ...handlers })
+        const ctrl = streamProvider({ provider: cfg.provider, messages: history, model: cfg.modelId, systemPrompt: cfg.systemPrompt, ...handlers })
         abortRefs.current[msgId] = ctrl
       })
     }, 0)
@@ -310,9 +307,7 @@ export function useChatStore(agents = []) {
           },
         }
 
-        const ctrl = cfg.provider === 'codex'
-          ? streamCodex({ messages: history, model: cfg.modelId, ...handlers })
-          : streamClaudeCode({ messages: history, model: cfg.modelId, systemPrompt: cfg.systemPrompt, ...handlers })
+        const ctrl = streamProvider({ provider: cfg.provider, messages: history, model: cfg.modelId, systemPrompt: cfg.systemPrompt, ...handlers })
 
         abortRefs.current[msgId] = ctrl
       })

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,12 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    port: 5173,
+    strictPort: true, // 端口占用时直接报错，不漂移，保证 bridge CORS 白名单可靠
+  },
+  preview: {
+    port: 4173,
+    strictPort: true,
+  },
 })


### PR DESCRIPTION
## 关联 Issue

Closes #2

## 变更内容

### bridge/gateway.js（新增）
- `POST /gateway/stream` 统一入口，按 `provider` 字段路由到对应 adapter
- 统一 SSE 事件格式：`{ type: 'chunk'|'usage'|'error'|'done', ... }`
- 统一处理 abort（客户端断开时取消上游请求）

### bridge/providers/claude.js（新增）
- Claude adapter，async generator 实现
- API Key 从 `process.env.CLAUDE_API_KEY` 读取，upstream 固定

### bridge/providers/codex.js（新增）
- Codex adapter，async generator 实现
- 通过 EventEmitter queue 将 child process 事件转为 async iterable
- 支持 signal abort

### bridge/server.js
- 注册 gateway，保留 `/claude/stream` `/codex/stream` 旧路由向后兼容

### src/agents/gatewayAgent.js（新增）
- 前端唯一 provider 请求入口，调用 `/gateway/stream`
- 不含任何 provider-specific 逻辑

### src/store/chatStore.js
- 移除 provider 分支判断，统一调用 `streamProvider`

### CLAUDE.md
- 更新架构图，明确 gateway 层边界

## 验收标准

- [x] Claude 与 Codex 都通过 `/gateway/stream` 工作
- [x] 前端不含 provider-specific 网络请求实现
- [x] 所有 provider 使用相同的流式事件协议
- [x] 新增第三个 provider 只需在 `bridge/providers/` 新建 adapter 并在 `gateway.js` 注册
- [x] 客户端断开时上游请求被取消