### PR TITLE
feat(issue-9): add unified gateway policy layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,9 @@ VITE_CODEX_BRIDGE_URL=http://localhost:4891
 
 # Codex 可执行文件路径（可选，覆盖 bridge/server.js 中的默认路径）
 # CODEX_EXE_PATH=C:\path\to\codex.exe
+
+# Gateway policy 配置（可选，以下为默认值）
+# GATEWAY_TIMEOUT_MS=60000       # 单次请求超时（毫秒）
+# GATEWAY_MAX_RETRIES=2          # 最大重试次数（仅限流/网络错误）
+# GATEWAY_RETRY_BASE_MS=500      # 重试基础等待时间（指数退避）
+# GATEWAY_MAX_CONCURRENCY=10     # 最大并发请求数

--- a/bridge/gateway.js
+++ b/bridge/gateway.js
@@ -6,6 +6,7 @@
  */
 import * as claude from './providers/claude.js'
 import * as codex from './providers/codex.js'
+import { withPolicy } from './policy.js'
 
 const PROVIDERS = { claudecode: claude, codex }
 
@@ -27,7 +28,7 @@ export function registerGateway(app, requireLocalToken) {
     res.on('close', () => ac.abort())
 
     try {
-      for await (const event of adapter.stream({ messages, model, systemPrompt, signal: ac.signal })) {
+      for await (const event of withPolicy(provider, adapter.stream, { messages, model, systemPrompt, signal: ac.signal })) {
         if (ac.signal.aborted) break
         res.write(`data: ${JSON.stringify(event)}\n\n`)
         if (event.type === 'done' || event.type === 'error') break

--- a/bridge/policy.js
+++ b/bridge/policy.js
@@ -116,7 +116,7 @@ export async function* withPolicy(provider, streamFn, params) {
           if (event.type === 'usage') usage = event.usage
 
           if (event.type === 'error') {
-            // 把 yielded error 转为内部错误，走 retry 判断，不直接透传
+            // 把 yielded error 转为内部错误，走 retry 判断，保留 status 供 isRetryable() 使用
             yieldedError = Object.assign(new Error(event.message || 'provider error'), { status: event.status })
             break
           }

--- a/bridge/policy.js
+++ b/bridge/policy.js
@@ -148,13 +148,14 @@ export async function* withPolicy(provider, streamFn, params) {
       }
 
       // adapter yielded error → 判断是否可重试
+      // 只有在尚未向客户端发出任何 chunk 时才重试，避免重复/损坏输出
       if (yieldedError) {
         lastErr = yieldedError
-        if (isRetryable(yieldedError) && attempt < POLICY.maxRetries) {
+        if (isRetryable(yieldedError) && attempt < POLICY.maxRetries && chunks === 0) {
           attempt++
           continue
         }
-        log('error', provider, 'request failed', { error: lastErr.message, attempts: attempt + 1 })
+        log('error', provider, 'request failed', { error: lastErr.message, attempts: attempt + 1, chunks })
         yield { type: 'error', message: lastErr.message }
         return
       }

--- a/bridge/policy.js
+++ b/bridge/policy.js
@@ -1,0 +1,155 @@
+/**
+ * Gateway Policy Layer
+ * 为所有 provider adapter 提供统一的：
+ * - 请求超时
+ * - retry / backoff（仅幂等场景）
+ * - 并发限流
+ * - 结构化日志
+ * - usage/cost 统计 hook
+ */
+
+// ── 配置 ──────────────────────────────────────────────────────────────────────
+
+const POLICY = {
+  timeoutMs: Number(process.env.GATEWAY_TIMEOUT_MS) || 60_000,
+  maxRetries: Number(process.env.GATEWAY_MAX_RETRIES) || 2,
+  retryBaseMs: Number(process.env.GATEWAY_RETRY_BASE_MS) || 500,
+  maxConcurrency: Number(process.env.GATEWAY_MAX_CONCURRENCY) || 10,
+}
+
+// ── 并发计数器 ────────────────────────────────────────────────────────────────
+
+let activeRequests = 0
+
+// ── 结构化日志 ────────────────────────────────────────────────────────────────
+
+function log(level, provider, msg, extra = {}) {
+  console[level]?.(JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    provider,
+    msg,
+    ...extra,
+  }))
+}
+
+// ── 可重试错误判断 ────────────────────────────────────────────────────────────
+// 只对网络/限流类错误重试，不重试业务错误（key 无效、内容违规等）
+
+function isRetryable(err) {
+  if (!err) return false
+  const msg = err.message || ''
+  return (
+    err.status === 429 ||
+    err.status === 503 ||
+    err.status === 502 ||
+    /network|ECONNRESET|ETIMEDOUT|socket hang up/i.test(msg)
+  )
+}
+
+// ── sleep ─────────────────────────────────────────────────────────────────────
+
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+// ── 核心：withPolicy ──────────────────────────────────────────────────────────
+
+/**
+ * 用 policy 层包装 provider adapter.stream，返回新的 async generator
+ * @param {string} provider
+ * @param {Function} streamFn  - adapter.stream(params) async generator factory
+ * @param {object} params      - { messages, model, systemPrompt, signal }
+ */
+export async function* withPolicy(provider, streamFn, params) {
+  // 并发限流
+  if (activeRequests >= POLICY.maxConcurrency) {
+    log('warn', provider, 'concurrency limit reached', { active: activeRequests, max: POLICY.maxConcurrency })
+    yield { type: 'error', message: `Gateway busy: too many concurrent requests (max ${POLICY.maxConcurrency})` }
+    return
+  }
+
+  activeRequests++
+  const startTs = Date.now()
+  log('info', provider, 'request start', { model: params.model })
+
+  let attempt = 0
+  let lastErr = null
+
+  while (attempt <= POLICY.maxRetries) {
+    if (attempt > 0) {
+      const delay = POLICY.retryBaseMs * 2 ** (attempt - 1)
+      log('warn', provider, 'retrying', { attempt, delayMs: delay, error: lastErr?.message })
+      await sleep(delay)
+    }
+
+    try {
+      // 超时控制：用独立 AbortController 包装，超时后 abort
+      const timeoutAc = new AbortController()
+      const timer = setTimeout(() => timeoutAc.abort(), POLICY.timeoutMs)
+
+      // 合并外部 signal 和超时 signal
+      const signal = params.signal
+        ? anyAbort(params.signal, timeoutAc.signal)
+        : timeoutAc.signal
+
+      let usage = null
+      let chunks = 0
+
+      try {
+        for await (const event of streamFn({ ...params, signal })) {
+          if (event.type === 'chunk') chunks++
+          if (event.type === 'usage') usage = event.usage
+          yield event
+          if (event.type === 'done' || event.type === 'error') break
+        }
+      } finally {
+        clearTimeout(timer)
+      }
+
+      // 成功：记录 usage
+      log('info', provider, 'request done', {
+        durationMs: Date.now() - startTs,
+        chunks,
+        usage,
+        attempt,
+      })
+      activeRequests--
+      return
+
+    } catch (err) {
+      lastErr = err
+
+      if (params.signal?.aborted) {
+        log('info', provider, 'request aborted by client', { durationMs: Date.now() - startTs })
+        activeRequests--
+        return
+      }
+
+      if (err.name === 'AbortError' && !params.signal?.aborted) {
+        // 超时
+        log('warn', provider, 'request timeout', { timeoutMs: POLICY.timeoutMs, attempt })
+        yield { type: 'error', message: `Request timed out after ${POLICY.timeoutMs}ms` }
+        activeRequests--
+        return
+      }
+
+      if (!isRetryable(err) || attempt >= POLICY.maxRetries) break
+      attempt++
+    }
+  }
+
+  // 重试耗尽
+  log('error', provider, 'request failed', { error: lastErr?.message, attempts: attempt + 1 })
+  yield { type: 'error', message: lastErr?.message || 'Unknown gateway error' }
+  activeRequests--
+}
+
+// ── 工具：任意一个 signal abort 即触发 ────────────────────────────────────────
+
+function anyAbort(...signals) {
+  const ac = new AbortController()
+  for (const s of signals) {
+    if (s.aborted) { ac.abort(); break }
+    s.addEventListener('abort', () => ac.abort(), { once: true })
+  }
+  return ac.signal
+}

--- a/bridge/policy.js
+++ b/bridge/policy.js
@@ -34,7 +34,6 @@ function log(level, provider, msg, extra = {}) {
 }
 
 // ── 可重试错误判断 ────────────────────────────────────────────────────────────
-// 只对网络/限流类错误重试，不重试业务错误（key 无效、内容违规等）
 
 function isRetryable(err) {
   if (!err) return false
@@ -50,6 +49,17 @@ function isRetryable(err) {
 // ── sleep ─────────────────────────────────────────────────────────────────────
 
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+// ── 合并多个 AbortSignal ──────────────────────────────────────────────────────
+
+function anyAbort(...signals) {
+  const ac = new AbortController()
+  for (const s of signals) {
+    if (s.aborted) { ac.abort(); break }
+    s.addEventListener('abort', () => ac.abort(), { once: true })
+  }
+  return ac.signal
+}
 
 // ── 核心：withPolicy ──────────────────────────────────────────────────────────
 
@@ -71,85 +81,106 @@ export async function* withPolicy(provider, streamFn, params) {
   const startTs = Date.now()
   log('info', provider, 'request start', { model: params.model })
 
-  let attempt = 0
-  let lastErr = null
+  // finally 块保证无论何种退出路径都释放计数
+  try {
+    let attempt = 0
+    let lastErr = null
 
-  while (attempt <= POLICY.maxRetries) {
-    if (attempt > 0) {
-      const delay = POLICY.retryBaseMs * 2 ** (attempt - 1)
-      log('warn', provider, 'retrying', { attempt, delayMs: delay, error: lastErr?.message })
-      await sleep(delay)
-    }
+    while (attempt <= POLICY.maxRetries) {
+      if (attempt > 0) {
+        const delay = POLICY.retryBaseMs * 2 ** (attempt - 1)
+        log('warn', provider, 'retrying', { attempt, delayMs: delay, error: lastErr?.message })
+        await sleep(delay)
+      }
 
-    try {
-      // 超时控制：用独立 AbortController 包装，超时后 abort
+      // 客户端已断开，不再重试
+      if (params.signal?.aborted) {
+        log('info', provider, 'request aborted by client', { durationMs: Date.now() - startTs })
+        return
+      }
+
       const timeoutAc = new AbortController()
       const timer = setTimeout(() => timeoutAc.abort(), POLICY.timeoutMs)
-
-      // 合并外部 signal 和超时 signal
       const signal = params.signal
         ? anyAbort(params.signal, timeoutAc.signal)
         : timeoutAc.signal
 
       let usage = null
       let chunks = 0
+      let yieldedError = null  // adapter 以 event 形式 yield 的错误
+      let timedOut = false
 
       try {
         for await (const event of streamFn({ ...params, signal })) {
           if (event.type === 'chunk') chunks++
           if (event.type === 'usage') usage = event.usage
+
+          if (event.type === 'error') {
+            // 把 yielded error 转为内部错误，走 retry 判断，不直接透传
+            yieldedError = Object.assign(new Error(event.message || 'provider error'), { status: event.status })
+            break
+          }
+
           yield event
-          if (event.type === 'done' || event.type === 'error') break
+          if (event.type === 'done') break
         }
       } finally {
         clearTimeout(timer)
+        // 超时：timeoutAc 已 abort 但客户端未 abort
+        if (timeoutAc.signal.aborted && !params.signal?.aborted) {
+          timedOut = true
+        }
       }
 
-      // 成功：记录 usage
+      // 客户端主动断开
+      if (params.signal?.aborted) {
+        log('info', provider, 'request aborted by client', { durationMs: Date.now() - startTs })
+        return
+      }
+
+      // 超时
+      if (timedOut) {
+        log('warn', provider, 'request timeout', { timeoutMs: POLICY.timeoutMs, attempt })
+        lastErr = Object.assign(new Error(`Request timed out after ${POLICY.timeoutMs}ms`), { _timeout: true })
+        // 超时不重试（流式请求不幂等）
+        yield { type: 'error', message: lastErr.message }
+        return
+      }
+
+      // adapter yielded error → 判断是否可重试
+      if (yieldedError) {
+        lastErr = yieldedError
+        if (isRetryable(yieldedError) && attempt < POLICY.maxRetries) {
+          attempt++
+          continue
+        }
+        log('error', provider, 'request failed', { error: lastErr.message, attempts: attempt + 1 })
+        yield { type: 'error', message: lastErr.message }
+        return
+      }
+
+      // 成功
       log('info', provider, 'request done', {
         durationMs: Date.now() - startTs,
         chunks,
         usage,
         attempt,
       })
-      activeRequests--
       return
-
-    } catch (err) {
-      lastErr = err
-
-      if (params.signal?.aborted) {
-        log('info', provider, 'request aborted by client', { durationMs: Date.now() - startTs })
-        activeRequests--
-        return
-      }
-
-      if (err.name === 'AbortError' && !params.signal?.aborted) {
-        // 超时
-        log('warn', provider, 'request timeout', { timeoutMs: POLICY.timeoutMs, attempt })
-        yield { type: 'error', message: `Request timed out after ${POLICY.timeoutMs}ms` }
-        activeRequests--
-        return
-      }
-
-      if (!isRetryable(err) || attempt >= POLICY.maxRetries) break
-      attempt++
     }
+
+    // 重试耗尽（thrown error 路径）
+    log('error', provider, 'request failed', { error: lastErr?.message, attempts: attempt + 1 })
+    yield { type: 'error', message: lastErr?.message || 'Unknown gateway error' }
+
+  } catch (err) {
+    if (params.signal?.aborted) {
+      log('info', provider, 'request aborted by client', { durationMs: Date.now() - startTs })
+      return
+    }
+    log('error', provider, 'unexpected error', { error: err.message })
+    yield { type: 'error', message: err.message }
+  } finally {
+    activeRequests--
   }
-
-  // 重试耗尽
-  log('error', provider, 'request failed', { error: lastErr?.message, attempts: attempt + 1 })
-  yield { type: 'error', message: lastErr?.message || 'Unknown gateway error' }
-  activeRequests--
-}
-
-// ── 工具：任意一个 signal abort 即触发 ────────────────────────────────────────
-
-function anyAbort(...signals) {
-  const ac = new AbortController()
-  for (const s of signals) {
-    if (s.aborted) { ac.abort(); break }
-    s.addEventListener('abort', () => ac.abort(), { once: true })
-  }
-  return ac.signal
 }

--- a/bridge/providers/claude.js
+++ b/bridge/providers/claude.js
@@ -38,6 +38,6 @@ export async function* stream({ messages, model = 'claude-sonnet-4-6', systemPro
     }
     if (!signal?.aborted) yield { type: 'done' }
   } catch (err) {
-    if (!signal?.aborted) yield { type: 'error', message: err.message }
+    if (!signal?.aborted) yield { type: 'error', message: err.message, status: err.status ?? err.statusCode }
   }
 }


### PR DESCRIPTION
## 关联 Issue

Closes #9

## 变更内容

### bridge/policy.js（新增）
统一 policy 层，所有 provider 共用：
- **超时**：`GATEWAY_TIMEOUT_MS`（默认 60s），每次请求独立 AbortController
- **retry/backoff**：`GATEWAY_MAX_RETRIES`（默认 2），仅对 429/503/网络错误重试，指数退避
- **并发限流**：`GATEWAY_MAX_CONCURRENCY`（默认 10），超限直接返回 error event
- **结构化日志**：每次请求 start/done/retry/error/abort 输出 JSON 日志，含 provider、duration、usage、attempt
- **usage hook**：done 时汇总 chunks 数和 usage 数据写入日志

### bridge/gateway.js
- `adapter.stream` 调用改为 `withPolicy(provider, adapter.stream, params)`

### .env.example
- 新增 `GATEWAY_*` 配置项说明

## 验收标准

- [x] provider 请求有明确超时处理
- [x] retry/backoff 集中定义，不在各 provider 内分散实现
- [x] 并发控制 hook 在 bridge 层统一生效
- [x] usage/logging 通过共享 policy 契约输出
- [x] 新增 provider 只需实现 `stream()` adapter，policy 自动生效