### PR TITLE
docs: fix stale status and architecture in CLAUDE.md and README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@
   gateway policy 层（timeout / retry / concurrency / logging）✓
 
 下一步
-  issue #9 follow-up: gateway policy 进一步完善（per-provider 策略差异）
+  gateway policy 进一步完善（per-provider 策略差异、usage/cost 统计 hook）
   Agent 工作目录隔离（每会话独立 cwd）
 
 未来

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,8 @@
 |---|------|------|
 | P1-1 | API Key 暴露在前端 bundle | ✅ 已修复（Key 移入 bridge process.env，Redis 过滤敏感字段） |
 | P1-2 | 会话 ID 自增，刷新后冲突 | ✅ 已修复（UUID） |
-| P1-3 | streaming 期间频繁写 Redis | 待修复 |
-| P1-4 | sendMessage 闭包快照导致历史丢失 | 待修复 |
+| P1-3 | streaming 期间频繁写 Redis | ✅ 已修复（600ms 防抖，conversations 变化时写） |
+| P1-4 | sendMessage 闭包快照导致历史丢失 | ✅ 已修复（activeIdRef 同步读取） |
 | P1-5 | codex bridge 丢弃多轮上下文 | ✅ 已修复（历史拼接） |
 
 ## 演进路径
@@ -51,10 +51,11 @@
 ```
 当前（MVP）
   多 Agent 并发对话 ✓ / Redis 持久化 ✓ / 停止切换会话 ✓
+  统一 provider gateway ✓ / bridge-only auth ✓ / CORS + token 鉴权 ✓
+  gateway policy 层（timeout / retry / concurrency / logging）✓
 
 下一步
-  P1-3 Redis 写入防抖
-  P1-4 sendMessage 闭包修复
+  issue #9 follow-up: gateway policy 进一步完善（per-provider 策略差异）
   Agent 工作目录隔离（每会话独立 cwd）
 
 未来

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,10 @@
   gateway policy 层（timeout / retry / concurrency / logging）✓
 
 下一步
-  gateway policy 进一步完善（per-provider 策略差异、usage/cost 统计 hook）
   Agent 工作目录隔离（每会话独立 cwd）
+  消息导出（Markdown/JSON）
 
 未来
-  消息导出（Markdown/JSON）
   Agent 自定义 system prompt
   Codex 原生多轮 API 支持
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ bridge/server.js  (Express :4891)
 - 前端唯一状态源：`useChatStore` + `useAgentStore`（无 Zustand/Redux）
 - Bridge 是唯一外部通信出口，API Key 仅在 bridge `process.env` 中，不进前端 bundle
 - 会话 ID 全部使用 `crypto.randomUUID()`
-- CORS + local token 双重校验，仅允许本机前端访问
+- `/gateway/stream` 等 AI 路由受 local token 鉴权保护；`/conversations`、`/agents` 等数据路由依赖 CORS 白名单（localhost:5173/4173），无 token 校验
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 | # | 问题 |
 |---|------|
-| P1-5 | issue #9 gateway policy 后续：usage 统计 hook、per-provider 限流 |
+| P1-5 | gateway policy 扩展：usage/cost 统计 hook、per-provider 限流策略 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | 多 Agent 并发对话 | 同一条消息同时发给多个 AI，并排流式展示回复 |
 | @mention 路由 | AI 回复中 `@name` 自动触发目标 Agent 响应，支持链式协作 |
 | 会话持久化 | Redis 存储全量会话，刷新不丢失，UUID 防冲突 |
-| 自定义 Agent | 可配置任意 Claude / Codex 模型、system prompt、API Key |
+| 自定义 Agent | 可配置任意 Claude / Codex 模型、system prompt |
 | 流式输出 + 停止 | 实时显示 token，支持随时中断所有 Agent |
 | Token 统计 | 每条回复显示 input/output token 用量 |
 | Bridge 中转 | 前端不直连 AI API，全部经由本地 Express bridge |
@@ -28,8 +28,7 @@
 
 | # | 问题 |
 |---|------|
-| P1-1 | API Key 目前仍可通过前端 bundle 读取，需移入 bridge `process.env` |
-| P1-3 | streaming 期间每 chunk 触发 Redis 写入，需防抖至 `onDone` 时写 |
+| P1-5 | issue #9 gateway policy 后续：usage 统计 hook、per-provider 限流 |
 
 ---
 
@@ -37,19 +36,21 @@
 
 ```
 浏览器 (Vite + React + Tailwind)
-         ↕  fetch / SSE
+         ↕  fetch / SSE  (localhost:4891, local token auth)
 bridge/server.js  (Express :4891)
-         ↕
-  Redis :6379          Anthropic API
-  cat-cafe:conversations    /v1/messages
-  cat-cafe:agents
-         ↕
-  codex.exe  (OpenAI Codex CLI，可选)
+         ↕                    ↕
+  Redis :6379          gateway.js + policy.js
+  cat-cafe:conversations    ↕              ↕
+  cat-cafe:agents    providers/claude.js  providers/codex.js
+                          ↕                    ↕
+                    Anthropic API          codex.exe (本地)
+                    /v1/messages
 ```
 
 - 前端唯一状态源：`useChatStore` + `useAgentStore`（无 Zustand/Redux）
-- Bridge 是唯一外部通信出口，持有 API Key
+- Bridge 是唯一外部通信出口，API Key 仅在 bridge `process.env` 中，不进前端 bundle
 - 会话 ID 全部使用 `crypto.randomUUID()`
+- CORS + local token 双重校验，仅允许本机前端访问
 
 ---
 
@@ -79,8 +80,9 @@ cp .env.example .env
 编辑 `.env`：
 
 ```env
-VITE_CLAUDE_API_KEY=sk-ant-xxxxxxxx
-VITE_CLAUDE_BASE_URL=https://api.anthropic.com
+# Bridge 侧 Claude API Key（只在 bridge/server.js 中读取，不进前端 bundle）
+CLAUDE_API_KEY=sk-ant-xxxxxxxx
+
 VITE_CODEX_BRIDGE_URL=http://localhost:4891
 
 # 可选：指定 codex.exe 路径
@@ -104,7 +106,7 @@ npm run dev
 | 布偶猫 | claude-sonnet-4-6 | Anthropic API |
 | 缅因猫 | gpt-5.4 | Codex CLI（本地） |
 
-在右侧边栏可添加、编辑、删除 Agent，配置项包括：模型 ID、API Key、Base URL、System Prompt。
+在右侧边栏可添加、编辑、删除 Agent，配置项包括：模型 ID、System Prompt。API Key 统一在 bridge `.env` 中配置，不在 UI 中暴露。
 
 ---
 
@@ -121,8 +123,7 @@ npm run dev
 ```
 src/
   agents/
-    claudeCodeAgent.js   # Anthropic API 流式请求封装
-    codexAgent.js        # Codex CLI SSE 封装
+    gatewayAgent.js      # 统一 gateway SSE 封装（所有 provider 共用）
   components/
     Sidebar.jsx          # 会话列表
     MainChatArea.jsx     # 消息流展示
@@ -135,7 +136,12 @@ src/
     chatStore.js         # 会话 / 消息 / 流式状态
     agentStore.js        # Agent 配置管理
 bridge/
-  server.js              # Express 桥接，spawn codex.exe，Redis 读写
+  server.js              # Express 桥接，Redis 读写，local token 鉴权
+  gateway.js             # Provider 路由，SSE 输出
+  policy.js              # 超时 / 重试 / 限流 / 日志
+  providers/
+    claude.js            # Anthropic API 适配器
+    codex.js             # Codex CLI 适配器
 ```
 
 ---


### PR DESCRIPTION
## 变更内容

修复 #11 和 #12 中报告的文档漂移问题。

### CLAUDE.md
- P1-3（Redis 防抖）标记为 ✅ 已修复
- P1-4（sendMessage 闭包）标记为 ✅ 已修复
- 演进路径更新：gateway policy 层标记为已完成，添加 issue #9 后续跟进项

### README.md
- 移除 `VITE_CLAUDE_API_KEY` / `VITE_CLAUDE_BASE_URL`（已移入 bridge `process.env`）
- 架构图更新：展示 gateway → policy → providers 层级
- 待完成表格：移除已修复的 P1-1 和 P1-3
- 目录结构：`claudeCodeAgent.js` / `codexAgent.js` → `gatewayAgent.js` + `bridge/providers/*`
- Agent 配置说明：移除 per-agent API Key / Base URL 字段描述

Closes #11
Closes #12