### PR TITLE
docs: fix stale documentation and update AGENTS.md collaboration guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,11 @@ PR status guidance:
 
 Codex reviewing a ClaudeCode PR must classify findings into one of 3 buckets:
 
+Before patching any review finding, ClaudeCode must:
+1. State the classification (A/B/C below)
+2. Restate the technical invariant being protected (e.g. "activeRequests must always decrement on every exit path")
+3. Check all related exit paths / call sites for the same class of defect before writing any code
+
 ### A. In-scope and small
 Examples:
 - edge case missed
@@ -246,10 +251,22 @@ Minimum expectation:
 - run lint / typecheck if configured
 - include exact validation commands in the PR description
 
+For async stream / generator subsystems, explicitly trace all exit paths before patching:
+- normal completion
+- timeout
+- yielded error event
+- thrown error
+- client abort
+
 If tests cannot run:
 - say so explicitly
 - explain why
 - provide best-effort manual verification steps
+
+When debugging intertwined failure modes in one subsystem:
+- model all exit paths first with hypothesis logs
+- identify the shared root cause before writing any patch
+- do not patch one exit path in isolation if others share the same invariant
 
 ---
 
@@ -269,13 +286,14 @@ Do not:
 ## 13. Preferred collaboration pattern
 
 Default pattern:
-1. ClaudeCode implements from issue on a feature/fix branch
-2. PR opened to GitHub
-3. Codex reviews the PR
-4. Findings are classified as in-scope small / in-scope risky / out-of-scope
-5. ClaudeCode fixes small in-scope findings on same branch
-6. Larger or out-of-scope findings become follow-up issues / PRs
-7. Human decides merge timing and scope boundaries
+1. For cross-layer changes (UI model, bridge API, Redis schema, docs), write a short design doc listing explicit invariants and "not allowed" fields before touching code
+2. ClaudeCode implements from issue on a feature/fix branch
+3. PR opened to GitHub
+4. Codex reviews the PR
+5. Findings are classified as in-scope small / in-scope risky / out-of-scope
+6. ClaudeCode fixes small in-scope findings on same branch
+7. Larger or out-of-scope findings become follow-up issues / PRs
+8. Human decides merge timing and scope boundaries
 
 ---
 
@@ -287,5 +305,6 @@ A PR is ready to merge only if:
 - tests/docs are updated as needed
 - risks are documented
 - no unresolved scope ambiguity remains
+- for stream/async subsystems: all exit paths (normal, timeout, yielded error, thrown error, client abort) have been explicitly verified
 
 Correct and small beats clever and sprawling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,11 @@
 ```
 当前（MVP）
   多 Agent 并发对话 ✓ / Redis 持久化 ✓ / 停止切换会话 ✓
-  统一 provider gateway ✓ / bridge-only auth ✓ / CORS + token 鉴权 ✓
+  统一 provider gateway ✓
   gateway policy 层（timeout / retry / concurrency / logging）✓
 
 下一步
+  bridge auth 加固（issue #14 loopback bind、issue #15 数据路由鉴权）
   Agent 工作目录隔离（每会话独立 cwd）
   消息导出（Markdown/JSON）
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 一句话定位
 
-把多个智能体像小型研发团队一样协作落到工程现实：**可接入主流模型供应商、可视化协作、@mention 路由、会话持久化、可在浏览器中一键启动**。
+把多个智能体像小型研发团队一样协作落到工程现实：**可视化协作、@mention 路由、会话持久化、可在浏览器中一键启动**。当前内置 Claude 和 Codex 两个 provider，自定义后端连接（baseUrl / apiKey）尚未支持（见 issue #17）。
 
 ---
 
@@ -19,7 +19,7 @@
 | 多 Agent 并发对话 | 同一条消息同时发给多个 AI，并排流式展示回复 |
 | @mention 路由 | AI 回复中 `@name` 自动触发目标 Agent 响应，支持链式协作 |
 | 会话持久化 | Redis 存储全量会话，刷新不丢失，UUID 防冲突 |
-| 自定义 Agent | 可配置任意 Claude / Codex 模型、system prompt |
+| 自定义 Agent | 可配置 bridge 内置 provider（Claude / Codex）的模型 ID 和 system prompt；自定义后端连接暂不支持（见 issue #17） |
 | 流式输出 + 停止 | 实时显示 token，支持随时中断所有 Agent |
 | Token 统计 | 每条回复显示 input/output token 用量 |
 | Bridge 中转 | 前端不直连 AI API，全部经由本地 Express bridge |
@@ -28,7 +28,10 @@
 
 | # | 问题 |
 |---|------|
-| P1-5 | gateway policy 扩展：usage/cost 统计 hook、per-provider 限流策略 |
+| #14 | bridge 绑定所有接口，local token 可被 LAN 客户端通过 Host 头绕过 |
+| #15 | `/conversations` / `/agents` 数据路由无鉴权，任意可达客户端可读写 |
+| #17 | 自定义 Agent 无法配置 baseUrl / apiKey，无法连接非默认后端 |
+| #18 | bridge 不可用时前端仅显示通用 Failed to fetch，无明确错误提示 |
 
 ---
 


### PR DESCRIPTION
## 背景

基于 master（`fb07d6e`，PR #13 已合并）的增量变更。

## 变更内容

### AGENTS.md（新增协作规范，基于 2026-03-15 skill progression report）
- §7：patch 前先分类 review finding 并陈述被保护的技术不变量
- §11：新增 stream 退出路径追踪要求和系统性调试指导
- §13：跨层变更前要求先写设计文档列出 invariant
- §14：Definition of done 新增流式请求所有退出路径验证要求

### CLAUDE.md（修正演进路径过度声明）
- 移除 `bridge-only auth` / `CORS + token 鉴权` 的 ✓ 标记（issue #14、#15 仍 open）
- 下一步新增 bridge auth 加固项

### README.md（收窄产品定位和功能描述）
- 一句话定位移除"可接入主流模型供应商"，注明自定义后端连接暂不支持（issue #17）
- 自定义 Agent 功能描述收窄为实际支持范围
- 待完成表格替换为当前真实 open issues（#14、#15、#17、#18）

## 未变更内容

所有业务逻辑代码不变，无运行时影响。

## Risks

纯文档变更，无运行时风险。

## 验收标准

- [ ] CLAUDE.md 演进路径不包含未完成项的 ✓ 标记
- [ ] README.md 产品描述与实际实现能力一致
- [ ] AGENTS.md 协作规范反映 skill progression report 建议
- [ ] 待完成表格与 GitHub open issues 一致

docs-only change, no runnable checks configured, manually reviewed diff.