### PR TITLE
fix: bind bridge to loopback and require token on all state routes (close #14, #15)

### DIFF
--- a/bridge/server.js
+++ b/bridge/server.js
@@ -240,6 +240,14 @@ app.post('/codex/stream', requireLocalToken, (req, res) => {
 
 registerGateway(app, requireLocalToken)
 
-app.listen(4891, '127.0.0.1', () => {
-  console.log('[bridge] Codex bridge running on http://127.0.0.1:4891')
+// 同时绑定 IPv4 和 IPv6 loopback，避免 localhost 在 IPv6-first 环境解析到 ::1 时连接失败
+const PORT = 4891
+app.listen(PORT, '127.0.0.1', () => {
+  console.log(`[bridge] listening on http://127.0.0.1:${PORT}`)
+})
+app.listen(PORT, '::1', () => {
+  console.log(`[bridge] listening on http://[::1]:${PORT}`)
+}).on('error', (err) => {
+  // IPv6 不可用时静默忽略（部分 Windows 环境禁用 IPv6）
+  if (err.code !== 'EADDRNOTAVAIL') console.error('[bridge] IPv6 listen error:', err.message)
 })

--- a/bridge/server.js
+++ b/bridge/server.js
@@ -28,13 +28,8 @@ app.use(cors({
 }))
 app.use(express.json())
 
-// GET /token — 仅限 localhost 获取本地 token（供前端初始化时调用）
+// GET /token — 返回本地 token（bridge 已绑定 127.0.0.1，物理上只有 loopback 可达）
 app.get('/token', (req, res) => {
-  const host = req.hostname
-  if (host !== 'localhost' && host !== '127.0.0.1') {
-    res.status(403).json({ message: 'Forbidden' })
-    return
-  }
   res.json({ token: LOCAL_TOKEN })
 })
 
@@ -53,7 +48,7 @@ const CONV_KEY = 'cat-cafe:conversations'
 const AGENTS_KEY = 'cat-cafe:agents'
 
 // GET /conversations — 读取所有会话
-app.get('/conversations', async (req, res) => {
+app.get('/conversations', requireLocalToken, async (req, res) => {
   try {
     const data = await redis.get(CONV_KEY)
     res.json(data ? JSON.parse(data) : [])
@@ -64,7 +59,7 @@ app.get('/conversations', async (req, res) => {
 })
 
 // PUT /conversations — 覆盖保存所有会话
-app.put('/conversations', async (req, res) => {
+app.put('/conversations', requireLocalToken, async (req, res) => {
   try {
     await redis.set(CONV_KEY, JSON.stringify(req.body))
     res.json({ ok: true })
@@ -75,7 +70,7 @@ app.put('/conversations', async (req, res) => {
 })
 
 // GET /agents — 读取自定义 agents（过滤敏感字段）
-app.get('/agents', async (req, res) => {
+app.get('/agents', requireLocalToken, async (req, res) => {
   try {
     const data = await redis.get(AGENTS_KEY)
     const agents = data ? JSON.parse(data) : []
@@ -88,7 +83,7 @@ app.get('/agents', async (req, res) => {
 })
 
 // PUT /agents — 保存自定义 agents（过滤敏感字段）
-app.put('/agents', async (req, res) => {
+app.put('/agents', requireLocalToken, async (req, res) => {
   try {
     const safe = (Array.isArray(req.body) ? req.body : []).map(({ apiKey, baseUrl, ...rest }) => rest)
     await redis.set(AGENTS_KEY, JSON.stringify(safe))
@@ -245,6 +240,6 @@ app.post('/codex/stream', requireLocalToken, (req, res) => {
 
 registerGateway(app, requireLocalToken)
 
-app.listen(4891, () => {
-  console.log('[bridge] Codex bridge running on http://localhost:4891')
+app.listen(4891, '127.0.0.1', () => {
+  console.log('[bridge] Codex bridge running on http://127.0.0.1:4891')
 })

--- a/src/agents/gatewayAgent.js
+++ b/src/agents/gatewayAgent.js
@@ -8,7 +8,7 @@ const BRIDGE = import.meta.env.VITE_CODEX_BRIDGE_URL || 'http://localhost:4891'
 
 // 启动时从 bridge 获取本地 token，后续所有请求携带
 let localToken = null
-async function getToken() {
+export async function getToken() {
   if (localToken) return localToken
   try {
     const res = await fetch(`${BRIDGE}/token`)

--- a/src/agents/gatewayAgent.js
+++ b/src/agents/gatewayAgent.js
@@ -7,6 +7,7 @@
 const BRIDGE = import.meta.env.VITE_CODEX_BRIDGE_URL || 'http://localhost:4891'
 
 // 启动时从 bridge 获取本地 token，后续所有请求携带
+// bridge 重启后 token 会变化，调用方收到 401 时应调用 refreshToken() 后重试
 let localToken = null
 export async function getToken() {
   if (localToken) return localToken
@@ -18,6 +19,26 @@ export async function getToken() {
     console.error('[gateway] failed to fetch local token')
   }
   return localToken
+}
+
+export function refreshToken() {
+  localToken = null
+}
+
+/**
+ * 带 token 的 fetch，收到 401 时自动 refresh token 并重试一次
+ */
+export async function fetchWithToken(url, options = {}) {
+  const token = await getToken()
+  const headers = { ...options.headers, ...(token ? { 'x-local-token': token } : {}) }
+  const res = await fetch(url, { ...options, headers })
+  if (res.status === 401) {
+    refreshToken()
+    const newToken = await getToken()
+    const retryHeaders = { ...options.headers, ...(newToken ? { 'x-local-token': newToken } : {}) }
+    return fetch(url, { ...options, headers: retryHeaders })
+  }
+  return res
 }
 
 /**

--- a/src/store/agentStore.js
+++ b/src/store/agentStore.js
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import { getToken } from '../agents/gatewayAgent'
+import { fetchWithToken } from '../agents/gatewayAgent'
 
 const BRIDGE = import.meta.env.VITE_CODEX_BRIDGE_URL || 'http://localhost:4891'
 const AGENTS_KEY = 'cat-cafe:agents'
@@ -52,11 +52,7 @@ export function useAgentStore() {
   const isLoaded = { current: false }
 
   useEffect(() => {
-    getToken().then(token =>
-      fetch(`${BRIDGE}/agents`, {
-        headers: token ? { 'x-local-token': token } : {},
-      })
-    )
+    fetchWithToken(`${BRIDGE}/agents`)
       .then(r => r.json())
       .then(data => {
         if (Array.isArray(data) && data.length > 0) {
@@ -64,16 +60,11 @@ export function useAgentStore() {
         } else {
           // 首次加载：写入默认 agents
           setAgents(BUILTIN_AGENTS)
-          getToken().then(token =>
-            fetch(`${BRIDGE}/agents`, {
-              method: 'PUT',
-              headers: {
-                'Content-Type': 'application/json',
-                ...(token ? { 'x-local-token': token } : {}),
-              },
-              body: JSON.stringify(BUILTIN_AGENTS),
-            })
-          ).catch(() => {})
+          fetchWithToken(`${BRIDGE}/agents`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(BUILTIN_AGENTS),
+          }).catch(() => {})
         }
       })
       .catch(() => {})
@@ -81,16 +72,11 @@ export function useAgentStore() {
   }, [])
 
   const saveAgents = useCallback((list) => {
-    getToken().then(token =>
-      fetch(`${BRIDGE}/agents`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { 'x-local-token': token } : {}),
-        },
-        body: JSON.stringify(list),
-      })
-    ).catch(() => {})
+    fetchWithToken(`${BRIDGE}/agents`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(list),
+    }).catch(() => {})
   }, [])
 
   const createAgent = useCallback((data) => {

--- a/src/store/agentStore.js
+++ b/src/store/agentStore.js
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
+import { getToken } from '../agents/gatewayAgent'
 
 const BRIDGE = import.meta.env.VITE_CODEX_BRIDGE_URL || 'http://localhost:4891'
 const AGENTS_KEY = 'cat-cafe:agents'
@@ -51,7 +52,11 @@ export function useAgentStore() {
   const isLoaded = { current: false }
 
   useEffect(() => {
-    fetch(`${BRIDGE}/agents`)
+    getToken().then(token =>
+      fetch(`${BRIDGE}/agents`, {
+        headers: token ? { 'x-local-token': token } : {},
+      })
+    )
       .then(r => r.json())
       .then(data => {
         if (Array.isArray(data) && data.length > 0) {
@@ -59,11 +64,16 @@ export function useAgentStore() {
         } else {
           // 首次加载：写入默认 agents
           setAgents(BUILTIN_AGENTS)
-          fetch(`${BRIDGE}/agents`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(BUILTIN_AGENTS),
-          }).catch(() => {})
+          getToken().then(token =>
+            fetch(`${BRIDGE}/agents`, {
+              method: 'PUT',
+              headers: {
+                'Content-Type': 'application/json',
+                ...(token ? { 'x-local-token': token } : {}),
+              },
+              body: JSON.stringify(BUILTIN_AGENTS),
+            })
+          ).catch(() => {})
         }
       })
       .catch(() => {})
@@ -71,11 +81,16 @@ export function useAgentStore() {
   }, [])
 
   const saveAgents = useCallback((list) => {
-    fetch(`${BRIDGE}/agents`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(list),
-    }).catch(() => {})
+    getToken().then(token =>
+      fetch(`${BRIDGE}/agents`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { 'x-local-token': token } : {}),
+        },
+        body: JSON.stringify(list),
+      })
+    ).catch(() => {})
   }, [])
 
   const createAgent = useCallback((data) => {

--- a/src/store/chatStore.js
+++ b/src/store/chatStore.js
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { streamProvider } from '../agents/gatewayAgent'
+import { streamProvider, getToken } from '../agents/gatewayAgent'
 
 const newId = () => crypto.randomUUID()
 const newConvId = () => crypto.randomUUID()
@@ -70,7 +70,11 @@ export function useChatStore(agents = []) {
 
   const isLoaded = useRef(false)
   useEffect(() => {
-    fetch(`${BRIDGE}/conversations`)
+    getToken().then(token =>
+      fetch(`${BRIDGE}/conversations`, {
+        headers: token ? { 'x-local-token': token } : {},
+      })
+    )
       .then(r => r.json())
       .then(data => {
         if (Array.isArray(data) && data.length > 0) {
@@ -86,10 +90,14 @@ export function useChatStore(agents = []) {
   useEffect(() => {
     if (!isLoaded.current) return
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
-    saveTimerRef.current = setTimeout(() => {
+    saveTimerRef.current = setTimeout(async () => {
+      const token = await getToken()
       fetch(`${BRIDGE}/conversations`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { 'x-local-token': token } : {}),
+        },
         body: JSON.stringify(conversations),
       }).catch(err => console.warn('[store] save conversations failed:', err.message))
     }, 600)

--- a/src/store/chatStore.js
+++ b/src/store/chatStore.js
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { streamProvider, getToken } from '../agents/gatewayAgent'
+import { streamProvider, fetchWithToken } from '../agents/gatewayAgent'
 
 const newId = () => crypto.randomUUID()
 const newConvId = () => crypto.randomUUID()
@@ -70,11 +70,7 @@ export function useChatStore(agents = []) {
 
   const isLoaded = useRef(false)
   useEffect(() => {
-    getToken().then(token =>
-      fetch(`${BRIDGE}/conversations`, {
-        headers: token ? { 'x-local-token': token } : {},
-      })
-    )
+    fetchWithToken(`${BRIDGE}/conversations`)
       .then(r => r.json())
       .then(data => {
         if (Array.isArray(data) && data.length > 0) {
@@ -90,14 +86,10 @@ export function useChatStore(agents = []) {
   useEffect(() => {
     if (!isLoaded.current) return
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
-    saveTimerRef.current = setTimeout(async () => {
-      const token = await getToken()
-      fetch(`${BRIDGE}/conversations`, {
+    saveTimerRef.current = setTimeout(() => {
+      fetchWithToken(`${BRIDGE}/conversations`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { 'x-local-token': token } : {}),
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(conversations),
       }).catch(err => console.warn('[store] save conversations failed:', err.message))
     }, 600)


### PR DESCRIPTION
## What changed

- `bridge/server.js`: `app.listen` 改为绑定 `127.0.0.1`，消除 Host 头欺骗路径（#14）
- `bridge/server.js`: `/token` 路由移除 `req.hostname` 检查（loopback 绑定本身即是边界）
- `bridge/server.js`: `/conversations` GET/PUT 和 `/agents` GET/PUT 加上 `requireLocalToken`（#15）
- `src/agents/gatewayAgent.js`: `getToken` 改为 export，供 store 复用
- `src/store/chatStore.js`: 所有 bridge fetch 调用携带 `x-local-token`
- `src/store/agentStore.js`: 所有 bridge fetch 调用携带 `x-local-token`

## Why it changed

- #14：bridge 绑定所有接口时，LAN 客户端可通过伪造 `Host: localhost:4891` 绕过 `/token` 的 hostname 检查，获取 local token 后调用 provider 路由（包括 `codex exec --dangerously-bypass-approvals-and-sandbox`）
- #15：`/conversations` 和 `/agents` 无鉴权，任何可达客户端可读写会话历史和 agent 配置；CORS 白名单不是 auth 边界，`!origin` 路径对 curl 等非浏览器客户端完全开放

## What was not changed

- token 生成机制不变（`randomBytes(32)`，进程内单例）
- CORS 白名单不变（仍保留，作为浏览器层防护）
- `/claude/stream`、`/codex/stream`、`/gateway/stream` 鉴权逻辑不变
- gateway、policy、providers 层不变

## Risks

- bridge 绑定 `127.0.0.1` 后，非 loopback 访问将无法连接（预期行为，本地工具）
- 前端 `getToken()` 已有缓存，token 获取失败时 fetch 不带 header，bridge 返回 401；此场景与 bridge 不可用（#18）重叠，不在本 PR 范围内

## Validation steps

1. 启动 bridge，从 LAN 另一客户端尝试连接 `http://<host-ip>:4891/token` → 连接被拒绝
2. 不带 `x-local-token` 调用 `GET /conversations` → 401
3. 不带 `x-local-token` 调用 `PUT /agents` → 401
4. 正常启动前端，会话加载、保存、agent 管理均正常工作

## Linked issues

Closes #14
Closes #15