### PR TITLE
fix: surface bridge unavailable error instead of silent degradation (close #18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently -n bridge,vite -c cyan,green \"node bridge/server.js\" \"vite\"",
+    "dev": "concurrently --kill-others-on-fail -n bridge,vite -c cyan,green \"node bridge/server.js\" \"vite\"",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ export default function App() {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [activePage, setActivePage] = useState('chat') // 'chat' | 'catnest'
 
-  const { agents, createAgent, updateAgent, deleteAgent } = useAgentStore()
+  const { agents, bridgeError, createAgent, updateAgent, deleteAgent } = useAgentStore()
 
   const {
     conversations, activeId, messages, sessions,
@@ -31,6 +31,15 @@ export default function App() {
 
   return (
     <div className="flex h-screen w-full bg-white text-[#333333] font-sans overflow-hidden">
+      {bridgeError && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-xl shadow-xl p-8 max-w-md w-full mx-4 space-y-3">
+            <div className="text-red-500 font-semibold text-base">Bridge 不可用</div>
+            <div className="text-sm text-gray-600">{bridgeError}</div>
+            <div className="text-xs text-gray-400">请确认已运行 <code className="bg-gray-100 px-1 rounded">npm run dev</code> 并且 bridge 正常启动。</div>
+          </div>
+        </div>
+      )}
       <Sidebar
         conversations={conversations}
         activeId={activeId}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ export default function App() {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [activePage, setActivePage] = useState('chat') // 'chat' | 'catnest'
 
-  const { agents, bridgeError, createAgent, updateAgent, deleteAgent } = useAgentStore()
+  const { agents, bridgeError, retryBridgeLoad, createAgent, updateAgent, deleteAgent } = useAgentStore()
 
   const {
     conversations, activeId, messages, sessions,
@@ -36,7 +36,13 @@ export default function App() {
           <div className="bg-white rounded-xl shadow-xl p-8 max-w-md w-full mx-4 space-y-3">
             <div className="text-red-500 font-semibold text-base">Bridge 不可用</div>
             <div className="text-sm text-gray-600">{bridgeError}</div>
-            <div className="text-xs text-gray-400">请确认已运行 <code className="bg-gray-100 px-1 rounded">npm run dev</code> 并且 bridge 正常启动。</div>
+            <div className="text-xs text-gray-400">请确认 bridge 已启动，然后点击重试。</div>
+            <button
+              onClick={retryBridgeLoad}
+              className="mt-2 px-4 py-2 bg-[#D87C65] text-white text-sm rounded-lg hover:bg-[#C56A55] transition-colors"
+            >
+              重试
+            </button>
           </div>
         </div>
       )}

--- a/src/agents/gatewayAgent.js
+++ b/src/agents/gatewayAgent.js
@@ -16,7 +16,7 @@ export async function getToken() {
     const data = await res.json()
     localToken = data.token
   } catch {
-    console.error('[gateway] failed to fetch local token')
+    throw new Error('bridge unavailable: cannot reach http://localhost:4891 — make sure the bridge is running (npm run dev)')
   }
   return localToken
 }

--- a/src/agents/gatewayAgent.js
+++ b/src/agents/gatewayAgent.js
@@ -16,7 +16,7 @@ export async function getToken() {
     const data = await res.json()
     localToken = data.token
   } catch {
-    throw new Error('bridge unavailable: cannot reach http://localhost:4891 — make sure the bridge is running (npm run dev)')
+    throw new Error(`bridge unavailable: cannot reach ${BRIDGE} — make sure the bridge is running`)
   }
   return localToken
 }

--- a/src/store/agentStore.js
+++ b/src/store/agentStore.js
@@ -49,6 +49,7 @@ export function pickColors(idx) {
 
 export function useAgentStore() {
   const [agents, setAgents] = useState(BUILTIN_AGENTS)
+  const [bridgeError, setBridgeError] = useState(null)
   const isLoaded = { current: false }
 
   useEffect(() => {
@@ -67,7 +68,7 @@ export function useAgentStore() {
           }).catch(() => {})
         }
       })
-      .catch(() => {})
+      .catch(err => setBridgeError(err.message))
       .finally(() => { isLoaded.current = true })
   }, [])
 
@@ -112,5 +113,5 @@ export function useAgentStore() {
     })
   }, [saveAgents])
 
-  return { agents, createAgent, updateAgent, deleteAgent }
+  return { agents, bridgeError, createAgent, updateAgent, deleteAgent }
 }

--- a/src/store/agentStore.js
+++ b/src/store/agentStore.js
@@ -52,14 +52,14 @@ export function useAgentStore() {
   const [bridgeError, setBridgeError] = useState(null)
   const isLoaded = { current: false }
 
-  useEffect(() => {
+  const loadAgents = () => {
+    setBridgeError(null)
     fetchWithToken(`${BRIDGE}/agents`)
       .then(r => r.json())
       .then(data => {
         if (Array.isArray(data) && data.length > 0) {
           setAgents(data)
         } else {
-          // 首次加载：写入默认 agents
           setAgents(BUILTIN_AGENTS)
           fetchWithToken(`${BRIDGE}/agents`, {
             method: 'PUT',
@@ -70,7 +70,9 @@ export function useAgentStore() {
       })
       .catch(err => setBridgeError(err.message))
       .finally(() => { isLoaded.current = true })
-  }, [])
+  }
+
+  useEffect(() => { loadAgents() }, [])
 
   const saveAgents = useCallback((list) => {
     fetchWithToken(`${BRIDGE}/agents`, {
@@ -113,5 +115,5 @@ export function useAgentStore() {
     })
   }, [saveAgents])
 
-  return { agents, bridgeError, createAgent, updateAgent, deleteAgent }
+  return { agents, bridgeError, retryBridgeLoad: loadAgents, createAgent, updateAgent, deleteAgent }
 }


### PR DESCRIPTION
## What changed

- `package.json`: `concurrently` 加 `--kill-others-on-fail`，bridge 崩溃时 vite 进程也退出，dev 启动不再半死不活
- `src/agents/gatewayAgent.js`: `getToken()` 失败时抛出明确错误（`bridge unavailable: cannot reach ...`），不再静默返回 `null`
- `src/store/agentStore.js`: 捕获 bridge fetch 错误，暴露 `bridgeError` 状态
- `src/App.jsx`: `bridgeError` 非空时渲染全屏遮罩，显示具体错误信息和操作提示

## Why it changed

Issue #18：bridge 不可用时，`getToken()` 静默返回 `null`，前端继续发请求，最终只显示通用 `Failed to fetch`。用户无法判断是 bridge 没启动、崩溃还是网络问题。

## What was not changed

- token 生成和鉴权机制不变
- `fetchWithToken` 的 401 refresh 逻辑不变
- `streamProvider` 的 `onError` 路径不变（bridge 不可用时错误会显示在消息气泡里）
- chatStore 的 conversations 加载失败仍 console.warn（bridge 不可用时 agentStore 已先拦截并显示 overlay）

## Risks

- `getToken()` 从返回 `null` 改为抛出错误，调用方需要能处理异常。`streamProvider` 和 `fetchWithToken` 均已有 try/catch 覆盖，无静默吞错风险。
- `--kill-others-on-fail` 会在 bridge 意外崩溃时同时终止 vite，开发者需要重新运行 `npm run dev`（预期行为）

## Validation steps

1. 不启动 bridge，直接运行 `vite`（或只启动前端）→ 页面显示"Bridge 不可用"遮罩，不显示空白/正常 UI
2. 正常运行 `npm run dev` → 无遮罩，功能正常
3. 运行中手动 kill bridge 进程 → vite 也退出（`--kill-others-on-fail` 生效）
4. 发送消息时 bridge 不可用 → 消息气泡显示 `[错误] bridge unavailable: ...`

## Linked issues

Closes #18