### PR TITLE
feat: support per-agent baseUrl and apiKey for custom backends (close #17)

### DIFF
--- a/bridge/gateway.js
+++ b/bridge/gateway.js
@@ -1,7 +1,7 @@
 /**
  * Provider Gateway
  * POST /gateway/stream
- * body: { provider, messages, model, systemPrompt }
+ * body: { provider, messages, model, systemPrompt, agentId }
  * 统一 SSE 输出: { type: 'chunk'|'usage'|'error'|'done', ... }
  */
 import * as claude from './providers/claude.js'
@@ -10,14 +10,27 @@ import { withPolicy } from './policy.js'
 
 const PROVIDERS = { claudecode: claude, codex }
 
-export function registerGateway(app, requireLocalToken) {
+export function registerGateway(app, requireLocalToken, redis, agentsKey) {
   app.post('/gateway/stream', requireLocalToken, async (req, res) => {
-    const { provider, messages = [], model, systemPrompt } = req.body
+    const { provider, messages = [], model, systemPrompt, agentId } = req.body
     const adapter = PROVIDERS[provider]
 
     if (!adapter) {
       res.status(400).json({ message: `Unknown provider: ${provider}` })
       return
+    }
+
+    // 查 agent 配置，取 apiKey/baseUrl（如有）
+    let agentConfig = {}
+    if (agentId && redis) {
+      try {
+        const data = await redis.get(agentsKey)
+        const agents = data ? JSON.parse(data) : []
+        const agent = agents.find(a => a.id === agentId)
+        if (agent) agentConfig = { apiKey: agent.apiKey, baseUrl: agent.baseUrl }
+      } catch {
+        // 查询失败时 fallback 到默认配置
+      }
     }
 
     res.setHeader('Content-Type', 'text/event-stream')
@@ -28,7 +41,7 @@ export function registerGateway(app, requireLocalToken) {
     res.on('close', () => ac.abort())
 
     try {
-      for await (const event of withPolicy(provider, adapter.stream, { messages, model, systemPrompt, signal: ac.signal })) {
+      for await (const event of withPolicy(provider, adapter.stream, { messages, model, systemPrompt, signal: ac.signal, ...agentConfig })) {
         if (ac.signal.aborted) break
         res.write(`data: ${JSON.stringify(event)}\n\n`)
         if (event.type === 'done' || event.type === 'error') break

--- a/bridge/providers/claude.js
+++ b/bridge/providers/claude.js
@@ -1,6 +1,6 @@
 /**
  * Claude provider adapter
- * 输入: { messages, model, systemPrompt }
+ * 输入: { messages, model, systemPrompt, apiKey?, baseUrl? }
  * 输出: async generator，yield { type, ... }
  */
 import Anthropic from '@anthropic-ai/sdk'
@@ -11,13 +11,16 @@ export function isAvailable() {
   return !!process.env.CLAUDE_API_KEY
 }
 
-export async function* stream({ messages, model = 'claude-sonnet-4-6', systemPrompt, signal }) {
-  if (!isAvailable()) {
+export async function* stream({ messages, model = 'claude-sonnet-4-6', systemPrompt, signal, apiKey, baseUrl }) {
+  const resolvedKey = apiKey || process.env.CLAUDE_API_KEY
+  if (!resolvedKey) {
     yield { type: 'error', message: 'CLAUDE_API_KEY not set in bridge environment' }
     return
   }
 
-  const client = new Anthropic({ apiKey: process.env.CLAUDE_API_KEY })
+  const clientOpts = { apiKey: resolvedKey }
+  if (baseUrl) clientOpts.baseURL = baseUrl
+  const client = new Anthropic(clientOpts)
 
   const params = { model, max_tokens: 8096, messages }
   if (systemPrompt) params.system = systemPrompt

--- a/bridge/server.js
+++ b/bridge/server.js
@@ -83,10 +83,21 @@ app.get('/agents', requireLocalToken, async (req, res) => {
 })
 
 // PUT /agents — 保存自定义 agents（保留 apiKey/baseUrl 在 Redis，不回传前端）
+// 前端不携带 apiKey/baseUrl，PUT 时从 Redis 已有记录 merge，防止覆盖丢失
 app.put('/agents', requireLocalToken, async (req, res) => {
   try {
-    const agents = Array.isArray(req.body) ? req.body : []
-    await redis.set(AGENTS_KEY, JSON.stringify(agents))
+    const incoming = Array.isArray(req.body) ? req.body : []
+    const existing = await redis.get(AGENTS_KEY)
+    const existingMap = {}
+    if (existing) {
+      for (const a of JSON.parse(existing)) existingMap[a.id] = a
+    }
+    const merged = incoming.map(a => ({
+      ...a,
+      apiKey: a.apiKey ?? existingMap[a.id]?.apiKey,
+      baseUrl: a.baseUrl ?? existingMap[a.id]?.baseUrl,
+    }))
+    await redis.set(AGENTS_KEY, JSON.stringify(merged))
     res.json({ ok: true })
   } catch (err) {
     console.error('[redis] set agents error:', err.message)

--- a/bridge/server.js
+++ b/bridge/server.js
@@ -82,11 +82,11 @@ app.get('/agents', requireLocalToken, async (req, res) => {
   }
 })
 
-// PUT /agents — 保存自定义 agents（过滤敏感字段）
+// PUT /agents — 保存自定义 agents（保留 apiKey/baseUrl 在 Redis，不回传前端）
 app.put('/agents', requireLocalToken, async (req, res) => {
   try {
-    const safe = (Array.isArray(req.body) ? req.body : []).map(({ apiKey, baseUrl, ...rest }) => rest)
-    await redis.set(AGENTS_KEY, JSON.stringify(safe))
+    const agents = Array.isArray(req.body) ? req.body : []
+    await redis.set(AGENTS_KEY, JSON.stringify(agents))
     res.json({ ok: true })
   } catch (err) {
     console.error('[redis] set agents error:', err.message)
@@ -238,7 +238,7 @@ app.post('/codex/stream', requireLocalToken, (req, res) => {
   })
 })
 
-registerGateway(app, requireLocalToken)
+registerGateway(app, requireLocalToken, redis, AGENTS_KEY)
 
 // 同时绑定 IPv4 和 IPv6 loopback，避免 localhost 在 IPv6-first 环境解析到 ::1 时连接失败
 const PORT = 4891

--- a/src/agents/gatewayAgent.js
+++ b/src/agents/gatewayAgent.js
@@ -51,7 +51,7 @@ export async function fetchWithToken(url, options = {}) {
  * @param {function} onError - (err) => void
  * @returns {AbortController}
  */
-export function streamProvider({ provider, messages, model, systemPrompt, onChunk, onDone, onError }) {
+export function streamProvider({ provider, messages, model, systemPrompt, agentId, onChunk, onDone, onError }) {
   const controller = new AbortController()
 
   const run = async () => {
@@ -59,6 +59,7 @@ export function streamProvider({ provider, messages, model, systemPrompt, onChun
       const token = await getToken()
       const body = { provider, messages, model }
       if (systemPrompt) body.systemPrompt = systemPrompt
+      if (agentId) body.agentId = agentId
 
       const res = await fetch(`${BRIDGE}/gateway/stream`, {
         method: 'POST',

--- a/src/components/CatNest.jsx
+++ b/src/components/CatNest.jsx
@@ -5,7 +5,7 @@ import CatIcon from './CatIcon'
 
 function AgentForm({ initial, onSave, onCancel }) {
   const [form, setForm] = useState(initial || {
-    name: '', provider: 'claudecode', modelId: '', systemPrompt: '',
+    name: '', provider: 'claudecode', modelId: '', systemPrompt: '', baseUrl: '', apiKey: '',
   })
   const [error, setError] = useState('')
   const set = (k, v) => { setError(''); setForm(f => ({ ...f, [k]: v })) }
@@ -47,6 +47,25 @@ function AgentForm({ initial, onSave, onCancel }) {
             value={form.modelId}
             onChange={e => set('modelId', e.target.value)}
             placeholder="如: claude-sonnet-4-6"
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65]"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-gray-500 mb-1 block">Base URL <span className="text-gray-300">（可选）</span></label>
+          <input
+            value={form.baseUrl}
+            onChange={e => set('baseUrl', e.target.value)}
+            placeholder="如: https://api.example.com"
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65]"
+          />
+        </div>
+        <div className="col-span-2">
+          <label className="text-xs text-gray-500 mb-1 block">API Key <span className="text-gray-300">（可选，留空使用 bridge 默认）</span></label>
+          <input
+            type="password"
+            value={form.apiKey}
+            onChange={e => set('apiKey', e.target.value)}
+            placeholder="sk-..."
             className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65]"
           />
         </div>

--- a/src/store/chatStore.js
+++ b/src/store/chatStore.js
@@ -196,7 +196,7 @@ export function useChatStore(agents = []) {
             setSessionStatus(convId, agentId, 'ERROR')
           },
         }
-        const ctrl = streamProvider({ provider: cfg.provider, messages: history, model: cfg.modelId, systemPrompt: cfg.systemPrompt, ...handlers })
+        const ctrl = streamProvider({ provider: cfg.provider, messages: history, model: cfg.modelId, systemPrompt: cfg.systemPrompt, agentId: agentId, ...handlers })
         abortRefs.current[msgId] = ctrl
       })
     }, 0)
@@ -307,7 +307,7 @@ export function useChatStore(agents = []) {
           },
         }
 
-        const ctrl = streamProvider({ provider: cfg.provider, messages: history, model: cfg.modelId, systemPrompt: cfg.systemPrompt, ...handlers })
+        const ctrl = streamProvider({ provider: cfg.provider, messages: history, model: cfg.modelId, systemPrompt: cfg.systemPrompt, agentId: agentId, ...handlers })
 
         abortRefs.current[msgId] = ctrl
       })


### PR DESCRIPTION
## What changed

- `bridge/server.js`: PUT /agents 不再 strip `apiKey`/`baseUrl`，完整存入 Redis；GET /agents 仍 strip 敏感字段，不回传前端
- `bridge/gateway.js`: `registerGateway` 接收 `redis` + `agentsKey`，请求携带 `agentId` 时从 Redis 查 agent 配置，取 `apiKey`/`baseUrl` 传给 provider
- `bridge/providers/claude.js`: `stream()` 接受 `apiKey`/`baseUrl` 参数，有值时覆盖默认值，无值时 fallback 到 `process.env.CLAUDE_API_KEY`
- `src/agents/gatewayAgent.js`: `streamProvider()` 接受并转发 `agentId`
- `src/store/chatStore.js`: 两处 `streamProvider` 调用均传入 `agentId`
- `src/components/CatNest.jsx`: `AgentForm` 新增 `Base URL`（可选）和 `API Key`（password 类型，可选）字段

## Why it changed

Issue #17：自定义 agent 创建流程端到端都不支持自定义后端连接。`apiKey`/`baseUrl` 在 PUT 时被 strip，provider 只读 `process.env`，UI 也没有对应字段，导致用户无法将 agent 指向非默认后端。

## What was not changed

- `apiKey` 永远不回传前端（GET /agents 继续 strip）
- Codex provider 不受影响（无 baseUrl/apiKey 概念）
- 旧路由 `/claude/stream`、`/codex/stream` 不变
- policy 层不变

## Security notes

- `apiKey` 仅存 Redis（bridge 侧），不进前端 bundle，符合 CLAUDE.md 红线
- `baseUrl` 存 Redis 并回传前端（非敏感），用于 UI 展示
- 前端表单 `apiKey` 字段使用 `type="password"`，不明文显示

## Validation steps

1. 新建 agent，填入自定义 `baseUrl` 和 `apiKey`，保存
2. GET /agents 返回结果中无 `apiKey` 字段，有 `baseUrl` 字段
3. Redis 中 `cat-cafe:agents` 包含完整 `apiKey`/`baseUrl`
4. 用该 agent 发送消息，bridge 使用 per-agent `apiKey`/`baseUrl` 调用 Claude API
5. 不填 `apiKey` 的 agent 仍使用 `process.env.CLAUDE_API_KEY`

## Linked issues

Closes #17