### PR TITLE
fix: strip @mention routing tokens from provider-visible history (close #23)

### DIFF
--- a/src/store/chatStore.js
+++ b/src/store/chatStore.js
@@ -44,7 +44,7 @@ function escapeRegExp(s) {
 }
 
 function stripMentions(text, agents = []) {
-  return agents.reduce((t, a) => t.replace(new RegExp(`@${escapeRegExp(a.name)}(?=\\s|$)`, 'g'), ''), text).trim()
+  return agents.reduce((t, a) => t.replace(new RegExp(`@${escapeRegExp(a.name)}(?=[^a-zA-Z0-9\\u4e00-\\u9fa5_]|$)`, 'g'), ''), text).trim()
 }
 
 function buildMeta(modelLabel, usage) {

--- a/src/store/chatStore.js
+++ b/src/store/chatStore.js
@@ -39,8 +39,12 @@ function parseMentions(text, agents = []) {
     .map(a => a.id)
 }
 
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function stripMentions(text, agents = []) {
-  return agents.reduce((t, a) => t.replace(new RegExp(`@${a.name}(?=\\s|$)`, 'g'), ''), text).trim()
+  return agents.reduce((t, a) => t.replace(new RegExp(`@${escapeRegExp(a.name)}(?=\\s|$)`, 'g'), ''), text).trim()
 }
 
 function buildMeta(modelLabel, usage) {
@@ -243,7 +247,7 @@ export function useChatStore(agents = []) {
       if (!currentConv) {
         const conv = makeConversation(activeAgents)
         resolvedConvId = conv.id
-        history = [{ role: 'user', content: userText }]
+        history = [{ role: 'user', content: stripMentions(userText, agentsRef.current) }]
         return [{ ...conv, label: userText.slice(0, 20), messages: [userMsg, ...agentMsgs] }, ...prev]
       }
 

--- a/src/store/chatStore.js
+++ b/src/store/chatStore.js
@@ -39,6 +39,10 @@ function parseMentions(text, agents = []) {
     .map(a => a.id)
 }
 
+function stripMentions(text, agents = []) {
+  return agents.reduce((t, a) => t.replace(new RegExp(`@${a.name}\\b`, 'g'), ''), text).trim()
+}
+
 function buildMeta(modelLabel, usage) {
   if (!usage) return modelLabel || ''
   return `${modelLabel || ''} · ${usage.input_tokens || 0}↑ ${usage.output_tokens || 0}↓`
@@ -153,7 +157,7 @@ export function useChatStore(agents = []) {
       history = mergeHistory(conv.messages
         .filter(m => m.role === 'user' || m.role === 'assistant')
         .slice(-10)
-        .map(m => ({ role: m.role, content: m.role === 'assistant' && m.name ? `[${m.name}]: ${m.content}` : m.content })))
+        .map(m => ({ role: m.role, content: m.role === 'assistant' && m.name ? `[${m.name}]: ${m.content}` : stripMentions(m.content, agentsRef.current) })))
       return prev.map(c => c.id !== convId ? c : {
         ...c,
         agents: [...c.agents, ...newAgents],
@@ -249,7 +253,7 @@ export function useChatStore(agents = []) {
         .slice(-10)
         .map(m => ({
           role: m.role,
-          content: m.role === 'assistant' && m.name ? `[${m.name}]: ${m.content}` : m.content,
+          content: m.role === 'assistant' && m.name ? `[${m.name}]: ${m.content}` : stripMentions(m.content, agentsRef.current),
         })))
 
       const firstMsg = currentConv.messages.length === 0

--- a/src/store/chatStore.js
+++ b/src/store/chatStore.js
@@ -40,7 +40,7 @@ function parseMentions(text, agents = []) {
 }
 
 function stripMentions(text, agents = []) {
-  return agents.reduce((t, a) => t.replace(new RegExp(`@${a.name}\\b`, 'g'), ''), text).trim()
+  return agents.reduce((t, a) => t.replace(new RegExp(`@${a.name}(?=\\s|$)`, 'g'), ''), text).trim()
 }
 
 function buildMeta(modelLabel, usage) {
@@ -157,7 +157,7 @@ export function useChatStore(agents = []) {
       history = mergeHistory(conv.messages
         .filter(m => m.role === 'user' || m.role === 'assistant')
         .slice(-10)
-        .map(m => ({ role: m.role, content: m.role === 'assistant' && m.name ? `[${m.name}]: ${m.content}` : stripMentions(m.content, agentsRef.current) })))
+        .map(m => ({ role: m.role, content: m.role === 'assistant' && m.name ? stripMentions(`[${m.name}]: ${m.content}`, agentsRef.current) : stripMentions(m.content, agentsRef.current) })))
       return prev.map(c => c.id !== convId ? c : {
         ...c,
         agents: [...c.agents, ...newAgents],
@@ -253,7 +253,7 @@ export function useChatStore(agents = []) {
         .slice(-10)
         .map(m => ({
           role: m.role,
-          content: m.role === 'assistant' && m.name ? `[${m.name}]: ${m.content}` : stripMentions(m.content, agentsRef.current),
+          content: m.role === 'assistant' && m.name ? stripMentions(`[${m.name}]: ${m.content}`, agentsRef.current) : stripMentions(m.content, agentsRef.current),
         })))
 
       const firstMsg = currentConv.messages.length === 0


### PR DESCRIPTION
## What changed

- `src/store/chatStore.js`: 新增 `stripMentions(text, agents)` 工具函数，用正则移除 `@AgentName` token
- `sendMessage()` 构建 history 时，user role 的 content 经过 `stripMentions` 处理后再传给 provider
- `triggerMentioned()` 构建 history 时同理

## Why it changed

Issue #23：`@AgentName` 既是路由控制语法，也被原样转发给 provider。Codex 等模型会把 `@缅因猫` 当作任务描述的一部分，导致回复偏离用户意图，出现"我正在处理 @mention 路由问题..."之类的元推理。

## What was not changed

- UI 显示不变，`@AgentName` 标签仍正常渲染
- 路由逻辑不变，`parseAgentsFromText` 在 strip 之前运行，mention 仍正确路由
- assistant 消息的 content 不做处理（`[AgentName]: ...` 前缀保留）
- `parseMentions` 在 assistant fullText 上检测链式 mention，不受影响

## Validation steps

1. 输入 `@缅因猫 帮我写一首诗`，provider 收到的 content 为 `帮我写一首诗`，路由到缅因猫
2. 输入 `@AgentA @AgentB 解释一下 TCP`，两个 agent 均收到 `解释一下 TCP`
3. 历史消息中的 `@mention` 在下一轮 history 构建时也被 strip

## Linked issues

Closes #23