### PR TITLE
docs: sync README and CLAUDE.md with current master state (close #24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@
   统一 provider gateway ✓
   gateway policy 层（timeout / retry / concurrency / logging）✓
   bridge auth 加固（loopback bind ✓、数据路由 token 鉴权 ✓）
-  per-agent 自定义后端连接（baseUrl / apiKey）✓
+  per-agent 自定义后端连接（baseUrl / apiKey，仅 Claude-compatible provider）✓
   bridge 不可用错误提示 + 重试 ✓
   @mention token 不泄漏进 provider prompt ✓
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@
 
 ## 不可漂移的红线
 
-1. **API Key 永远不进前端 bundle** — Claude/OpenAI key 只在 bridge `process.env` 中读取
+1. **API Key 永远不进前端 bundle** — Claude/OpenAI key 只在 bridge `process.env` 或 Redis（per-agent apiKey）中读取；`GET /agents` 永远 strip `apiKey` 字段，不回传前端
 2. **会话 ID 永远用 `crypto.randomUUID()`** — 禁止自增整数，刷新后会冲突
 3. **Redis 写入必须防抖** — 不在 streaming chunk 期间逐次写，至少 500ms 防抖或仅在 `onDone`/`stopAll` 时写
 4. **bridge 是唯一外部通信出口** — 前端只 fetch `localhost:4891`
@@ -45,6 +45,12 @@
 | P1-3 | streaming 期间频繁写 Redis | ✅ 已修复（600ms 防抖，conversations 变化时写） |
 | P1-4 | sendMessage 闭包快照导致历史丢失 | ✅ 已修复（activeIdRef 同步读取） |
 | P1-5 | codex bridge 丢弃多轮上下文 | ✅ 已修复（历史拼接） |
+| #14 | bridge 绑定所有接口，local token 可被 LAN 绕过 | ✅ 已修复（loopback bind） |
+| #15 | `/conversations` / `/agents` 无鉴权 | ✅ 已修复（local token auth） |
+| #17 | 自定义 Agent 无法配置 baseUrl / apiKey | ✅ 已修复（per-agent 后端连接支持） |
+| #18 | bridge 不可用时无明确错误提示 | ✅ 已修复（全屏错误横幅 + 重试） |
+| #23 | @mention token 泄漏进 provider prompt | ✅ 已修复（stripMentions） |
+| #16 | @mention 链式调用无循环保护 | 🔴 待修复 |
 
 ## 演进路径
 
@@ -53,14 +59,17 @@
   多 Agent 并发对话 ✓ / Redis 持久化 ✓ / 停止切换会话 ✓
   统一 provider gateway ✓
   gateway policy 层（timeout / retry / concurrency / logging）✓
+  bridge auth 加固（loopback bind ✓、数据路由 token 鉴权 ✓）
+  per-agent 自定义后端连接（baseUrl / apiKey）✓
+  bridge 不可用错误提示 + 重试 ✓
+  @mention token 不泄漏进 provider prompt ✓
 
 下一步
-  bridge auth 加固（issue #14 loopback bind、issue #15 数据路由鉴权）
+  @mention 链式调用循环保护（issue #16）
   Agent 工作目录隔离（每会话独立 cwd）
   消息导出（Markdown/JSON）
 
 未来
-  Agent 自定义 system prompt
   Codex 原生多轮 API 支持
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@
 | # | 问题 |
 |---|------|
 | #16 | @mention 链式调用无循环保护，可能无限触发 |
-| #23 | @mention 路由 token 泄漏进 provider prompt |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 一句话定位
 
-把多个智能体像小型研发团队一样协作落到工程现实：**可视化协作、@mention 路由、会话持久化、可在浏览器中一键启动**。当前内置 Claude 和 Codex 两个 provider，自定义后端连接（baseUrl / apiKey）尚未支持（见 issue #17）。
+把多个智能体像小型研发团队一样协作落到工程现实：**可视化协作、@mention 路由、会话持久化、可在浏览器中一键启动**。当前内置 Claude 和 Codex 两个 provider，支持为每个自定义 Agent 配置独立的 baseUrl / apiKey。
 
 ---
 
@@ -19,7 +19,7 @@
 | 多 Agent 并发对话 | 同一条消息同时发给多个 AI，并排流式展示回复 |
 | @mention 路由 | AI 回复中 `@name` 自动触发目标 Agent 响应，支持链式协作 |
 | 会话持久化 | Redis 存储全量会话，刷新不丢失，UUID 防冲突 |
-| 自定义 Agent | 可配置 bridge 内置 provider（Claude / Codex）的模型 ID 和 system prompt；自定义后端连接暂不支持（见 issue #17） |
+| 自定义 Agent | 可配置 provider（Claude / Codex）的模型 ID、System Prompt、baseUrl 和 apiKey；apiKey 仅存 bridge Redis，不回传前端 |
 | 流式输出 + 停止 | 实时显示 token，支持随时中断所有 Agent |
 | Token 统计 | 每条回复显示 input/output token 用量 |
 | Bridge 中转 | 前端不直连 AI API，全部经由本地 Express bridge |
@@ -28,10 +28,8 @@
 
 | # | 问题 |
 |---|------|
-| #14 | bridge 绑定所有接口，local token 可被 LAN 客户端通过 Host 头绕过 |
-| #15 | `/conversations` / `/agents` 数据路由无鉴权，任意可达客户端可读写 |
-| #17 | 自定义 Agent 无法配置 baseUrl / apiKey，无法连接非默认后端 |
-| #18 | bridge 不可用时前端仅显示通用 Failed to fetch，无明确错误提示 |
+| #16 | @mention 链式调用无循环保护，可能无限触发 |
+| #23 | @mention 路由 token 泄漏进 provider prompt |
 
 ---
 
@@ -51,9 +49,9 @@ bridge/server.js  (Express :4891)
 ```
 
 - 前端唯一状态源：`useChatStore` + `useAgentStore`（无 Zustand/Redux）
-- Bridge 是唯一外部通信出口，API Key 仅在 bridge `process.env` 中，不进前端 bundle
+- Bridge 是唯一外部通信出口，API Key 仅在 bridge `process.env` 或 Redis（per-agent）中，不进前端 bundle
 - 会话 ID 全部使用 `crypto.randomUUID()`
-- `/gateway/stream` 等 AI 路由受 local token 鉴权保护；`/conversations`、`/agents` 等数据路由依赖 CORS 白名单（localhost:5173/4173），无 token 校验
+- `/gateway/stream` 等 AI 路由及 `/conversations`、`/agents` 数据路由均受 local token 鉴权保护
 
 ---
 
@@ -109,7 +107,7 @@ npm run dev
 | 布偶猫 | claude-sonnet-4-6 | Anthropic API |
 | 缅因猫 | gpt-5.4 | Codex CLI（本地） |
 
-在右侧边栏可添加、编辑、删除 Agent，配置项包括：模型 ID、System Prompt。API Key 统一在 bridge `.env` 中配置，不在 UI 中暴露。
+在右侧边栏可添加、编辑、删除 Agent，配置项包括：模型 ID、System Prompt、Base URL（可选）、API Key（可选）。API Key 仅存 bridge Redis，不回传前端，留空则使用 bridge `.env` 中的默认 Key。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 一句话定位
 
-把多个智能体像小型研发团队一样协作落到工程现实：**可视化协作、@mention 路由、会话持久化、可在浏览器中一键启动**。当前内置 Claude 和 Codex 两个 provider，支持为每个自定义 Agent 配置独立的 baseUrl / apiKey。
+把多个智能体像小型研发团队一样协作落到工程现实：**可视化协作、@mention 路由、会话持久化、可在浏览器中一键启动**。当前内置 Claude 和 Codex 两个 provider，Claude-compatible backend 支持为每个自定义 Agent 配置独立的 baseUrl / apiKey；Codex provider 通过本地 CLI 调用，不支持自定义凭据。
 
 ---
 
@@ -19,7 +19,7 @@
 | 多 Agent 并发对话 | 同一条消息同时发给多个 AI，并排流式展示回复 |
 | @mention 路由 | AI 回复中 `@name` 自动触发目标 Agent 响应，支持链式协作 |
 | 会话持久化 | Redis 存储全量会话，刷新不丢失，UUID 防冲突 |
-| 自定义 Agent | 可配置 provider（Claude / Codex）的模型 ID、System Prompt、baseUrl 和 apiKey；apiKey 仅存 bridge Redis，不回传前端 |
+| 自定义 Agent | 可配置模型 ID、System Prompt；Claude provider 额外支持 baseUrl / apiKey（仅存 bridge Redis，不回传前端）；Codex provider 通过本地 CLI 调用，不支持自定义凭据 |
 | 流式输出 + 停止 | 实时显示 token，支持随时中断所有 Agent |
 | Token 统计 | 每条回复显示 input/output token 用量 |
 | Bridge 中转 | 前端不直连 AI API，全部经由本地 Express bridge |

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npm run dev
 | 布偶猫 | claude-sonnet-4-6 | Anthropic API |
 | 缅因猫 | gpt-5.4 | Codex CLI（本地） |
 
-在右侧边栏可添加、编辑、删除 Agent，配置项包括：模型 ID、System Prompt、Base URL（可选）、API Key（可选）。API Key 仅存 bridge Redis，不回传前端，留空则使用 bridge `.env` 中的默认 Key。
+在右侧边栏可添加、编辑、删除 Agent，配置项包括：模型 ID、System Prompt。Claude-compatible provider 额外支持 Base URL（可选）和 API Key（可选），API Key 仅存 bridge Redis，不回传前端，留空则使用 bridge `.env` 中的默认 Key；Codex provider 通过本地 CLI 调用，不支持自定义凭据。
 
 ---
 


### PR DESCRIPTION
## What changed

**README.md**
- 一句话定位移除"自定义后端连接尚未支持（见 issue #17）"
- 已完成表格：自定义 Agent 条目更新，反映 baseUrl/apiKey 支持
- 架构说明：`/conversations`、`/agents` 现在也受 local token 鉴权，更新描述
- 内置 Agent 说明：配置项加入 Base URL / API Key，说明 apiKey 仅存 Redis
- 待完成表格：移除已关闭的 #14/#15/#17/#18，保留 #16/#23

**CLAUDE.md**
- 红线 #1：更新为"key 只在 bridge process.env 或 Redis（per-agent）中，GET /agents 永远 strip apiKey"
- 已知问题状态表：补充 #14/#15/#17/#18/#23 为已修复
- 演进路径：已完成项移入当前状态，下一步只保留 #16，移除已完成的 auth 加固和 system prompt

## Why it changed

Issue #24：PR #20/21/22 合并后文档未同步，README 仍将 #17/#18 列为 pending，仍描述无 token auth，CLAUDE.md 红线和 roadmap 与实际代码矛盾。

## Linked issues

Closes #24