### PR TITLE
feat: add delete conversation with 2-min confirm grace period (close #28)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ export default function App() {
   const {
     conversations, activeId, messages, sessions,
     createConversation, switchConversation, sendMessage, stopAll,
+    isConfirmRequired, confirmDelete,
   } = useChatStore(agents)
 
   const handleStart = (agentIds) => {
@@ -54,6 +55,9 @@ export default function App() {
         onOpenNewChat={() => setIsModalOpen(true)}
         onSwitch={handleSwitch}
         onOpenCatNest={() => setActivePage(p => p === 'catnest' ? 'chat' : 'catnest')}
+        onDelete={confirmDelete}
+        onConfirmDelete={confirmDelete}
+        isConfirmRequired={isConfirmRequired}
       />
 
       {activePage === 'catnest' ? (

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,10 +1,15 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Menu, Search, Edit3, BarChart2, ListTodo, Home, Book, Calendar, Settings, ChevronDown, Trash2, X, Check } from 'lucide-react'
 import CatIcon from './CatIcon'
 
 export default function Sidebar({ conversations, activeId, onOpenNewChat, onSwitch, onOpenCatNest, activePage, agents = [], onDelete, onConfirmDelete, isConfirmRequired }) {
   const agentMap = agents.reduce((acc, a) => { acc[a.id] = a; return acc }, {})
   const [pendingDeleteId, setPendingDeleteId] = useState(null)
+  useEffect(() => {
+    if (pendingDeleteId && !conversations.find(c => c.id === pendingDeleteId)) {
+      setPendingDeleteId(null)
+    }
+  }, [conversations, pendingDeleteId])
   const navItems = [
     { icon: <Edit3 size={16} />, label: '发起新对话', action: onOpenNewChat },
     { icon: <BarChart2 size={16} />, label: '数据看板' },
@@ -67,12 +72,14 @@ export default function Sidebar({ conversations, activeId, onOpenNewChat, onSwit
                     <button
                       onClick={e => { e.stopPropagation(); onConfirmDelete(conv.id); setPendingDeleteId(null) }}
                       className="p-1 text-red-500 hover:bg-red-50 rounded"
+                      aria-label="确认删除"
                     >
                       <Check size={13} />
                     </button>
                     <button
                       onClick={e => { e.stopPropagation(); setPendingDeleteId(null) }}
                       className="p-1 text-gray-400 hover:bg-gray-200 rounded"
+                      aria-label="取消删除"
                     >
                       <X size={13} />
                     </button>
@@ -96,6 +103,7 @@ export default function Sidebar({ conversations, activeId, onOpenNewChat, onSwit
                           }
                         }}
                         className="opacity-0 group-hover:opacity-100 p-1 text-gray-400 hover:text-red-500 hover:bg-white/60 rounded transition-opacity"
+                        aria-label={`删除会话 ${conv.label}`}
                       >
                         <Trash2 size={13} />
                       </button>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,8 +1,10 @@
-import { Menu, Search, Edit3, BarChart2, ListTodo, Home, Book, Calendar, Settings, ChevronDown } from 'lucide-react'
+import { useState } from 'react'
+import { Menu, Search, Edit3, BarChart2, ListTodo, Home, Book, Calendar, Settings, ChevronDown, Trash2, X, Check } from 'lucide-react'
 import CatIcon from './CatIcon'
 
-export default function Sidebar({ conversations, activeId, onOpenNewChat, onSwitch, onOpenCatNest, activePage, agents = [] }) {
+export default function Sidebar({ conversations, activeId, onOpenNewChat, onSwitch, onOpenCatNest, activePage, agents = [], onDelete, onConfirmDelete, isConfirmRequired }) {
   const agentMap = agents.reduce((acc, a) => { acc[a.id] = a; return acc }, {})
+  const [pendingDeleteId, setPendingDeleteId] = useState(null)
   const navItems = [
     { icon: <Edit3 size={16} />, label: '发起新对话', action: onOpenNewChat },
     { icon: <BarChart2 size={16} />, label: '数据看板' },
@@ -55,22 +57,59 @@ export default function Sidebar({ conversations, activeId, onOpenNewChat, onSwit
           {conversations.map((conv) => (
             <div
               key={conv.id}
-              onClick={() => onSwitch(conv.id)}
-              className={`flex flex-col px-3 py-2 rounded-lg cursor-pointer transition-colors ${conv.id === activeId ? 'bg-[#EAEAEA] text-gray-900' : 'hover:bg-gray-100 text-gray-700'}`}
+              onClick={() => { if (pendingDeleteId !== conv.id) onSwitch(conv.id) }}
+              className={`group relative flex flex-col px-3 py-2 rounded-lg cursor-pointer transition-colors ${conv.id === activeId ? 'bg-[#EAEAEA] text-gray-900' : 'hover:bg-gray-100 text-gray-700'}`}
             >
-              <div className="flex items-center justify-between">
-                <span className="text-sm truncate pr-2 font-medium">{conv.label}</span>
-                <span className="text-xs text-gray-400 shrink-0">
-                  {new Date(conv.createdAt).toLocaleTimeString('zh', { hour: '2-digit', minute: '2-digit' })}
-                </span>
-              </div>
-              <div className="flex mt-1.5 space-x-1">
-                {conv.agents.map((agentType, i) => (
-                  <div key={i} className={`w-4 h-4 rounded-full ${agentMap[agentType]?.avatarColor || 'bg-gray-300'} border border-white flex items-center justify-center`}>
-                    <CatIcon size={10} color="white" />
+              {pendingDeleteId === conv.id ? (
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-gray-500">确认删除？</span>
+                  <div className="flex space-x-1">
+                    <button
+                      onClick={e => { e.stopPropagation(); onConfirmDelete(conv.id); setPendingDeleteId(null) }}
+                      className="p-1 text-red-500 hover:bg-red-50 rounded"
+                    >
+                      <Check size={13} />
+                    </button>
+                    <button
+                      onClick={e => { e.stopPropagation(); setPendingDeleteId(null) }}
+                      className="p-1 text-gray-400 hover:bg-gray-200 rounded"
+                    >
+                      <X size={13} />
+                    </button>
                   </div>
-                ))}
-              </div>
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm truncate pr-2 font-medium">{conv.label}</span>
+                    <div className="flex items-center space-x-1">
+                      <span className="text-xs text-gray-400 shrink-0">
+                        {new Date(conv.createdAt).toLocaleTimeString('zh', { hour: '2-digit', minute: '2-digit' })}
+                      </span>
+                      <button
+                        onClick={e => {
+                          e.stopPropagation()
+                          if (isConfirmRequired()) {
+                            setPendingDeleteId(conv.id)
+                          } else {
+                            onDelete(conv.id)
+                          }
+                        }}
+                        className="opacity-0 group-hover:opacity-100 p-1 text-gray-400 hover:text-red-500 hover:bg-white/60 rounded transition-opacity"
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                    </div>
+                  </div>
+                  <div className="flex mt-1.5 space-x-1">
+                    {conv.agents.map((agentType, i) => (
+                      <div key={i} className={`w-4 h-4 rounded-full ${agentMap[agentType]?.avatarColor || 'bg-gray-300'} border border-white flex items-center justify-center`}>
+                        <CatIcon size={10} color="white" />
+                      </div>
+                    ))}
+                  </div>
+                </>
+              )}
             </div>
           ))}
         </div>

--- a/src/store/chatStore.js
+++ b/src/store/chatStore.js
@@ -207,7 +207,7 @@ export function useChatStore(agents = []) {
   const lastConfirmedAt = useRef(0)
 
   const deleteConversation = useCallback((convId) => {
-    let fallbackId = null
+    const fallbackRef = { current: null }
     setConversations(prev => {
       const conv = prev.find(c => c.id === convId)
       if (conv) {
@@ -219,10 +219,10 @@ export function useChatStore(agents = []) {
         })
       }
       const next = prev.filter(c => c.id !== convId)
-      fallbackId = next.length > 0 ? next[0].id : null
+      fallbackRef.current = next.length > 0 ? next[0].id : null
       return next
     })
-    setActiveIdSynced(current => current === convId ? fallbackId : current)
+    setActiveIdSynced(current => current === convId ? fallbackRef.current : current)
   }, [setActiveIdSynced])
 
   const isConfirmRequired = useCallback(() => {
@@ -363,7 +363,6 @@ export function useChatStore(agents = []) {
     switchConversation,
     sendMessage,
     stopAll,
-    deleteConversation,
     isConfirmRequired,
     confirmDelete,
   }

--- a/src/store/chatStore.js
+++ b/src/store/chatStore.js
@@ -204,6 +204,36 @@ export function useChatStore(agents = []) {
 
   const abortRefs = useRef({})
 
+  const lastConfirmedAt = useRef(0)
+
+  const deleteConversation = useCallback((convId) => {
+    let fallbackId = null
+    setConversations(prev => {
+      const conv = prev.find(c => c.id === convId)
+      if (conv) {
+        conv.messages.forEach(m => {
+          if (m.streaming && abortRefs.current[m.id]) {
+            abortRefs.current[m.id].abort()
+            delete abortRefs.current[m.id]
+          }
+        })
+      }
+      const next = prev.filter(c => c.id !== convId)
+      fallbackId = next.length > 0 ? next[0].id : null
+      return next
+    })
+    setActiveIdSynced(current => current === convId ? fallbackId : current)
+  }, [setActiveIdSynced])
+
+  const isConfirmRequired = useCallback(() => {
+    return Date.now() - lastConfirmedAt.current >= 120_000
+  }, [])
+
+  const confirmDelete = useCallback((convId) => {
+    lastConfirmedAt.current = Date.now()
+    deleteConversation(convId)
+  }, [deleteConversation])
+
   const sendMessage = useCallback((userText, activeAgents) => {
     const userMsg = {
       id: newId(),
@@ -333,5 +363,8 @@ export function useChatStore(agents = []) {
     switchConversation,
     sendMessage,
     stopAll,
+    deleteConversation,
+    isConfirmRequired,
+    confirmDelete,
   }
 }


### PR DESCRIPTION
## Changes
- `useChatStore`: add `isConfirmRequired`, `confirmDelete`（内部 `deleteConversation` 不暴露，防止绕过确认机制）
- `Sidebar`: hover 显示 trash 图标；首次删除展开 inline confirm；2 分钟 grace period 内直接删除；图标按钮均有 aria-label；conversations 变化时自动清理 stale `pendingDeleteId`
- `App.jsx`: 透传新 props 给 Sidebar

## Behavior
- Hover 会话行 → 右侧出现删除图标
- 首次删除：行内展开"确认删除？"+ ✓/✗ 按钮
- 确认后 2 分钟内：再次删除直接生效，无需确认
- 删除 active 会话：自动切换到列表第一条，列表为空则置 null
- 删除含 streaming 消息的会话：自动 abort 所有进行中的请求

Closes #28