### PR TITLE
feat: add dark mode with bounce toggle animation (close #27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 *.local
 .claude/
+.worktrees/

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,10 +6,12 @@ import NewChatModal from './components/NewChatModal'
 import CatNest from './components/CatNest'
 import { useChatStore } from './store/chatStore'
 import { useAgentStore } from './store/agentStore'
+import { useTheme } from './store/themeStore'
 
 export default function App() {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [activePage, setActivePage] = useState('chat') // 'chat' | 'catnest'
+  const { isDark, toggle } = useTheme()
 
   const { agents, bridgeError, retryBridgeLoad, createAgent, updateAgent, deleteAgent } = useAgentStore()
 
@@ -31,13 +33,13 @@ export default function App() {
   }
 
   return (
-    <div className="flex h-screen w-full bg-white text-[#333333] font-sans overflow-hidden">
+    <div className="flex h-screen w-full bg-white dark:bg-gray-900 text-[#333333] dark:text-gray-100 font-sans overflow-hidden transition-colors duration-300">
       {bridgeError && (
         <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="bg-white rounded-xl shadow-xl p-8 max-w-md w-full mx-4 space-y-3">
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl p-8 max-w-md w-full mx-4 space-y-3">
             <div className="text-red-500 font-semibold text-base">Bridge 不可用</div>
-            <div className="text-sm text-gray-600">{bridgeError}</div>
-            <div className="text-xs text-gray-400">请确认 bridge 已启动，然后点击重试。</div>
+            <div className="text-sm text-gray-600 dark:text-gray-300">{bridgeError}</div>
+            <div className="text-xs text-gray-400 dark:text-gray-500">请确认 bridge 已启动，然后点击重试。</div>
             <button
               onClick={retryBridgeLoad}
               className="mt-2 px-4 py-2 bg-[#D87C65] text-white text-sm rounded-lg hover:bg-[#C56A55] transition-colors"
@@ -52,6 +54,8 @@ export default function App() {
         activeId={activeId}
         activePage={activePage}
         agents={agents}
+        isDark={isDark}
+        onToggleTheme={toggle}
         onOpenNewChat={() => setIsModalOpen(true)}
         onSwitch={handleSwitch}
         onOpenCatNest={() => setActivePage(p => p === 'catnest' ? 'chat' : 'catnest')}

--- a/src/components/CatNest.jsx
+++ b/src/components/CatNest.jsx
@@ -18,23 +18,23 @@ function AgentForm({ initial, onSave, onCancel }) {
   }
 
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-5 space-y-4 shadow-sm">
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-5 space-y-4 shadow-sm">
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className="text-xs text-gray-500 mb-1 block">名称 (用于 @)</label>
+          <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">名称 (用于 @)</label>
           <input
             value={form.name}
             onChange={e => set('name', e.target.value)}
             placeholder="如: 侦探猫"
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65]"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65] bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"
           />
         </div>
         <div>
-          <label className="text-xs text-gray-500 mb-1 block">Provider</label>
+          <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">Provider</label>
           <select
             value={form.provider}
             onChange={e => set('provider', e.target.value)}
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65] bg-white"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65] bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"
           >
             {Object.entries(PROVIDERS).map(([k, v]) => (
               <option key={k} value={k}>{v.label}</option>
@@ -42,47 +42,47 @@ function AgentForm({ initial, onSave, onCancel }) {
           </select>
         </div>
         <div>
-          <label className="text-xs text-gray-500 mb-1 block">Model ID</label>
+          <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">Model ID</label>
           <input
             value={form.modelId}
             onChange={e => set('modelId', e.target.value)}
             placeholder="如: claude-sonnet-4-6"
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65]"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65] bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"
           />
         </div>
         <div>
-          <label className="text-xs text-gray-500 mb-1 block">Base URL <span className="text-gray-300">（可选）</span></label>
+          <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">Base URL <span className="text-gray-300 dark:text-gray-600">（可选）</span></label>
           <input
             value={form.baseUrl}
             onChange={e => set('baseUrl', e.target.value)}
             placeholder="如: https://api.example.com"
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65]"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65] bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"
           />
         </div>
         <div className="col-span-2">
-          <label className="text-xs text-gray-500 mb-1 block">API Key <span className="text-gray-300">（可选，留空使用 bridge 默认）</span></label>
+          <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">API Key <span className="text-gray-300 dark:text-gray-600">（可选，留空使用 bridge 默认）</span></label>
           <input
             type="password"
             value={form.apiKey}
             onChange={e => set('apiKey', e.target.value)}
             placeholder="sk-..."
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65]"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65] bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"
           />
         </div>
         <div className="col-span-2">
-          <label className="text-xs text-gray-500 mb-1 block">System Prompt</label>
+          <label className="text-xs text-gray-500 dark:text-gray-400 mb-1 block">System Prompt</label>
           <textarea
             value={form.systemPrompt}
             onChange={e => set('systemPrompt', e.target.value)}
             placeholder="你是一只..."
             rows={3}
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65] resize-none"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2 text-sm outline-none focus:border-[#D87C65] resize-none bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100"
           />
         </div>
       </div>
       {error && <div className="text-xs text-red-500 px-1">{error}</div>}
       <div className="flex justify-end space-x-2">
-        <button onClick={onCancel} className="px-4 py-2 text-sm text-gray-500 hover:bg-gray-100 rounded-lg">取消</button>
+        <button onClick={onCancel} className="px-4 py-2 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">取消</button>
         <button
           onClick={handleSave}
           disabled={!valid}
@@ -105,11 +105,11 @@ export default function CatNest({ agents, onCreate, onUpdate, onDelete }) {
   }, {})
 
   return (
-    <div className="flex-1 flex flex-col h-full bg-white relative min-w-0">
-      <div className="flex items-center justify-between px-6 py-3 border-b border-gray-100">
+    <div className="flex-1 flex flex-col h-full bg-white dark:bg-gray-900 relative min-w-0 transition-colors duration-300">
+      <div className="flex items-center justify-between px-6 py-3 border-b border-gray-100 dark:border-gray-700">
         <div className="flex items-center space-x-3">
-          <h1 className="text-lg font-semibold text-gray-800">猫窝</h1>
-          <span className="text-sm text-gray-400">Agent 管理</span>
+          <h1 className="text-lg font-semibold text-gray-800 dark:text-gray-100">猫窝</h1>
+          <span className="text-sm text-gray-400 dark:text-gray-500">Agent 管理</span>
         </div>
         <button
           onClick={() => setCreating(true)}
@@ -139,8 +139,8 @@ export default function CatNest({ agents, onCreate, onUpdate, onDelete }) {
           <div key={providerKey}>
             <div className="flex items-center space-x-2 mb-3">
               <span className={`w-2.5 h-2.5 rounded-full ${provider.color}`} />
-              <h2 className="text-sm font-semibold text-gray-600">{provider.label}</h2>
-              <span className="text-xs text-gray-400">{byProvider[providerKey]?.length || 0} agents</span>
+              <h2 className="text-sm font-semibold text-gray-600 dark:text-gray-300">{provider.label}</h2>
+              <span className="text-xs text-gray-400 dark:text-gray-500">{byProvider[providerKey]?.length || 0} agents</span>
             </div>
             <div className="space-y-3">
               {(byProvider[providerKey] || []).map(agent => (
@@ -152,29 +152,29 @@ export default function CatNest({ agents, onCreate, onUpdate, onDelete }) {
                       onCancel={() => setEditingId(null)}
                     />
                   ) : (
-                    <div className={`${agent.bgColor} border border-gray-100 rounded-xl p-4 flex items-start justify-between`}>
+                    <div className={`${agent.bgColor} border border-gray-100 dark:border-gray-700 rounded-xl p-4 flex items-start justify-between`}>
                       <div className="flex items-start space-x-3">
                         <div className={`w-9 h-9 rounded-full ${agent.avatarColor} flex items-center justify-center shrink-0 shadow-sm`}>
                           <CatIcon size={20} color="white" />
                         </div>
                         <div>
                           <div className="flex items-center space-x-2">
-                            <span className="text-sm font-semibold text-gray-800">{agent.name}</span>
-                            <span className="text-xs text-gray-400 bg-white/60 px-1.5 py-0.5 rounded">@{agent.id}</span>
-                            {agent.builtin && <span className="text-xs text-[#D87C65] bg-[#FDF3EB] px-1.5 py-0.5 rounded">内置</span>}
+                            <span className="text-sm font-semibold text-gray-800 dark:text-gray-100">{agent.name}</span>
+                            <span className="text-xs text-gray-400 dark:text-gray-500 bg-white/60 dark:bg-gray-700/60 px-1.5 py-0.5 rounded">@{agent.id}</span>
+                            {agent.builtin && <span className="text-xs text-[#D87C65] bg-[#FDF3EB] dark:bg-orange-900/30 px-1.5 py-0.5 rounded">内置</span>}
                           </div>
-                          <div className="text-xs text-gray-500 mt-1">{agent.modelId}</div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">{agent.modelId}</div>
                           {agent.systemPrompt && (
-                            <div className="text-xs text-gray-400 mt-1 line-clamp-2 max-w-sm">{agent.systemPrompt}</div>
+                            <div className="text-xs text-gray-400 dark:text-gray-500 mt-1 line-clamp-2 max-w-sm">{agent.systemPrompt}</div>
                           )}
                         </div>
                       </div>
                       {!agent.builtin && (
                         <div className="flex space-x-1 shrink-0">
-                          <button onClick={() => setEditingId(agent.id)} className="p-1.5 text-gray-400 hover:text-gray-700 hover:bg-white/60 rounded-lg">
+                          <button onClick={() => setEditingId(agent.id)} className="p-1.5 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-white/60 dark:hover:bg-gray-700 rounded-lg">
                             <Edit2 size={14} />
                           </button>
-                          <button onClick={() => onDelete(agent.id)} className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-white/60 rounded-lg">
+                          <button onClick={() => onDelete(agent.id)} className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-white/60 dark:hover:bg-gray-700 rounded-lg">
                             <Trash2 size={14} />
                           </button>
                         </div>
@@ -184,7 +184,7 @@ export default function CatNest({ agents, onCreate, onUpdate, onDelete }) {
                 </div>
               ))}
               {(byProvider[providerKey] || []).length === 0 && (
-                <div className="text-xs text-gray-400 py-3 px-4 border border-dashed border-gray-200 rounded-xl text-center">
+                <div className="text-xs text-gray-400 dark:text-gray-500 py-3 px-4 border border-dashed border-gray-200 dark:border-gray-700 rounded-xl text-center">
                   暂无 {provider.label} agents
                 </div>
               )}

--- a/src/components/ChatInput.jsx
+++ b/src/components/ChatInput.jsx
@@ -141,18 +141,18 @@ export default function ChatInput({ onSend, agents = [] }) {
   const canSend = text.trim() && mentionedAgents.length > 0
 
   return (
-    <div className="px-6 pb-6 pt-2 bg-gradient-to-t from-white via-white to-transparent absolute bottom-0 w-full z-10">
+    <div className="px-6 pb-6 pt-2 bg-gradient-to-t from-white via-white dark:from-gray-900 dark:via-gray-900 to-transparent absolute bottom-0 w-full z-10">
       {/* @ 选择面板 */}
       {atQuery !== null && filtered.length > 0 && (
         <div
           ref={panelRef}
-          className="absolute bottom-full mb-2 left-6 bg-white border border-gray-200 rounded-xl shadow-lg overflow-hidden z-20 min-w-[220px]"
+          className="absolute bottom-full mb-2 left-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg overflow-hidden z-20 min-w-[220px]"
         >
           {providerFilter && (
             <button
               onMouseDown={(e) => e.preventDefault()}
               onClick={() => setProviderFilter(null)}
-              className="flex items-center space-x-2 w-full px-4 py-2 text-xs text-gray-400 hover:bg-gray-50 border-b border-gray-100"
+              className="flex items-center space-x-2 w-full px-4 py-2 text-xs text-gray-400 dark:text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 border-b border-gray-100 dark:border-gray-700"
             >
               <ChevronRight size={12} className="rotate-180" />
               <span>返回</span>
@@ -165,16 +165,16 @@ export default function ChatInput({ onSend, agents = [] }) {
               onMouseDown={(e) => e.preventDefault()}
               onClick={() => selectItem(item)}
               onMouseEnter={() => setSelectedIdx(idx)}
-              className={`flex items-center justify-between w-full px-4 py-2.5 text-left transition-colors ${idx === selectedIdx ? 'bg-[#FDF3EB]' : 'hover:bg-gray-50'}`}
+              className={`flex items-center justify-between w-full px-4 py-2.5 text-left transition-colors ${idx === selectedIdx ? 'bg-[#FDF3EB] dark:bg-orange-900/30' : 'hover:bg-gray-50 dark:hover:bg-gray-700'}`}
             >
               {item.type === 'provider' ? (
                 <>
                   <div className="flex items-center space-x-2">
                     <span className={`w-2.5 h-2.5 rounded-full ${item.data.color}`} />
-                    <span className="text-sm text-gray-700">{item.data.label}</span>
-                    <span className="text-xs text-gray-400">{agents.filter(a => a.provider === item.key).length} agents</span>
+                    <span className="text-sm text-gray-700 dark:text-gray-200">{item.data.label}</span>
+                    <span className="text-xs text-gray-400 dark:text-gray-500">{agents.filter(a => a.provider === item.key).length} agents</span>
                   </div>
-                  <ChevronRight size={14} className="text-gray-400" />
+                  <ChevronRight size={14} className="text-gray-400 dark:text-gray-500" />
                 </>
               ) : (
                 <>
@@ -182,14 +182,14 @@ export default function ChatInput({ onSend, agents = [] }) {
                     <div className={`w-5 h-5 rounded-full ${item.data.avatarColor} flex items-center justify-center`}>
                       <CatIcon size={12} color="white" />
                     </div>
-                    <span className="text-sm text-gray-700">{item.data.name}</span>
+                    <span className="text-sm text-gray-700 dark:text-gray-200">{item.data.name}</span>
                   </div>
-                  <span className="text-xs text-gray-400 ml-4">@{item.data.name}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500 ml-4">@{item.data.name}</span>
                 </>
               )}
             </button>
           ))}
-          <div className="px-4 py-1.5 border-t border-gray-100 flex space-x-3 text-[11px] text-gray-400">
+          <div className="px-4 py-1.5 border-t border-gray-100 dark:border-gray-700 flex space-x-3 text-[11px] text-gray-400 dark:text-gray-500">
             <span>↑↓ 选择</span><span>Tab/Enter 确认</span><span>Esc 返回</span>
           </div>
         </div>
@@ -208,7 +208,7 @@ export default function ChatInput({ onSend, agents = [] }) {
         </div>
       )}
 
-      <div className="relative flex items-end border border-gray-200 bg-[#FBFBFB] rounded-2xl p-2 shadow-sm focus-within:ring-1 focus-within:ring-[#D87C65]/30 focus-within:border-[#D87C65]/50 transition-all">
+      <div className="relative flex items-end border border-gray-200 dark:border-gray-600 bg-[#FBFBFB] dark:bg-gray-800 rounded-2xl p-2 shadow-sm focus-within:ring-1 focus-within:ring-[#D87C65]/30 focus-within:border-[#D87C65]/50 transition-all">
         <div className="p-2 text-gray-400 hover:text-gray-600 cursor-pointer mb-1 shrink-0">
           <Paperclip size={20} />
         </div>
@@ -217,21 +217,21 @@ export default function ChatInput({ onSend, agents = [] }) {
           value={text}
           onChange={handleInput}
           onKeyDown={handleKeyDown}
-          className="flex-1 max-h-48 min-h-[44px] bg-transparent border-none focus:ring-0 resize-none py-3 px-2 text-[15px] text-gray-800 placeholder-gray-400 outline-none leading-relaxed"
+          className="flex-1 max-h-48 min-h-[44px] bg-transparent border-none focus:ring-0 resize-none py-3 px-2 text-[15px] text-gray-800 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 outline-none leading-relaxed"
           placeholder="输入 @ 召唤 Agent... (Enter 发送, Shift+Enter 换行)"
           rows={1}
         />
         <div className="flex items-center space-x-1 p-2 mb-1 shrink-0">
-          <div className="p-1.5 text-gray-300 hover:text-gray-500 cursor-pointer rounded-full hover:bg-gray-100">
+          <div className="p-1.5 text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 cursor-pointer rounded-full hover:bg-gray-100 dark:hover:bg-gray-700">
             <Lock size={18} />
           </div>
-          <div className="p-1.5 text-gray-300 hover:text-gray-500 cursor-pointer rounded-full hover:bg-gray-100">
+          <div className="p-1.5 text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 cursor-pointer rounded-full hover:bg-gray-100 dark:hover:bg-gray-700">
             <Mic size={18} />
           </div>
           <button
             onClick={handleSend}
             disabled={!canSend}
-            className={`p-2 rounded-full ml-1 transition-colors ${canSend ? 'bg-[#D87C65] text-white hover:bg-[#C56A55] cursor-pointer' : 'bg-gray-100 text-gray-400 cursor-not-allowed'}`}
+            className={`p-2 rounded-full ml-1 transition-colors ${canSend ? 'bg-[#D87C65] text-white hover:bg-[#C56A55] cursor-pointer' : 'bg-gray-100 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed'}`}
           >
             <Send size={16} className="ml-0.5" />
           </button>

--- a/src/components/MainChatArea.jsx
+++ b/src/components/MainChatArea.jsx
@@ -12,13 +12,13 @@ export default function MainChatArea({ messages, sessions, onSend, onStop, agent
   }, [messages])
 
   return (
-    <div className="flex-1 flex flex-col h-full bg-white relative min-w-0">
-      <div className="flex items-center justify-between px-6 py-3 border-b border-gray-100 bg-white z-10">
+    <div className="flex-1 flex flex-col h-full bg-white dark:bg-gray-900 relative min-w-0 transition-colors duration-300">
+      <div className="flex items-center justify-between px-6 py-3 border-b border-gray-100 dark:border-gray-700 bg-white dark:bg-gray-900 z-10">
         <div className="flex items-center space-x-3">
-          <h1 className="text-lg font-semibold text-gray-800">Cat Cafe</h1>
-          <span className="text-sm text-gray-400">AI 猫猫协作空间</span>
+          <h1 className="text-lg font-semibold text-gray-800 dark:text-gray-100">Cat Cafe</h1>
+          <span className="text-sm text-gray-400 dark:text-gray-500">AI 猫猫协作空间</span>
         </div>
-        <div className="flex items-center space-x-4 text-gray-400">
+        <div className="flex items-center space-x-4 text-gray-400 dark:text-gray-500">
           {isStreaming && (
             <button
               onClick={onStop}
@@ -28,18 +28,18 @@ export default function MainChatArea({ messages, sessions, onSend, onStop, agent
               <span>停止</span>
             </button>
           )}
-          <div className="flex items-center space-x-3 border-r border-gray-200 pr-4">
-            <FileText size={18} className="cursor-pointer hover:text-gray-600" />
-            <Columns size={18} className="cursor-pointer hover:text-gray-600" />
-            <Download size={18} className="cursor-pointer hover:text-gray-600" />
+          <div className="flex items-center space-x-3 border-r border-gray-200 dark:border-gray-700 pr-4">
+            <FileText size={18} className="cursor-pointer hover:text-gray-600 dark:hover:text-gray-300" />
+            <Columns size={18} className="cursor-pointer hover:text-gray-600 dark:hover:text-gray-300" />
+            <Download size={18} className="cursor-pointer hover:text-gray-600 dark:hover:text-gray-300" />
           </div>
-          <MoreHorizontal size={20} className="cursor-pointer hover:text-gray-600" />
+          <MoreHorizontal size={20} className="cursor-pointer hover:text-gray-600 dark:hover:text-gray-300" />
         </div>
       </div>
 
       <div className="flex-1 overflow-y-auto px-6 py-6 space-y-6 custom-scrollbar pb-36">
         {messages.length === 0 && (
-          <div className="flex flex-col items-center justify-center h-full text-gray-400 space-y-2">
+          <div className="flex flex-col items-center justify-center h-full text-gray-400 dark:text-gray-500 space-y-2">
             <span className="text-4xl">🐱</span>
             <p className="text-sm">选择 Agent，开始对话</p>
           </div>

--- a/src/components/Messages.jsx
+++ b/src/components/Messages.jsx
@@ -18,17 +18,17 @@ export function BotMessage({ name, time, avatarColor, content, meta, bgColor, qu
       </div>
       <div className="ml-4 flex flex-col items-start w-full min-w-0">
         <div className="flex items-center space-x-2 mb-1.5">
-          <span className="text-sm font-medium text-gray-700">{name}</span>
-          <span className="text-xs text-gray-400">{time}</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{name}</span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">{time}</span>
           {streaming && <span className="text-xs text-green-500 animate-pulse">●</span>}
         </div>
         {quote && (
-          <div className="mb-2 pl-3 border-l-2 border-[#D87C65]/30 bg-[#FFF9F6] py-1.5 px-3 rounded-r-lg w-full max-w-[90%]">
-            <span className="text-[11px] text-gray-500 mb-0.5 block">回复 {quote.author}</span>
-            <p className="text-[13px] text-gray-600 line-clamp-2 leading-relaxed">{quote.text}</p>
+          <div className="mb-2 pl-3 border-l-2 border-[#D87C65]/30 bg-[#FFF9F6] dark:bg-orange-900/20 py-1.5 px-3 rounded-r-lg w-full max-w-[90%]">
+            <span className="text-[11px] text-gray-500 dark:text-gray-400 mb-0.5 block">回复 {quote.author}</span>
+            <p className="text-[13px] text-gray-600 dark:text-gray-300 line-clamp-2 leading-relaxed">{quote.text}</p>
           </div>
         )}
-        <div className={`${bgColor} text-gray-800 text-[15px] px-5 py-4 rounded-2xl rounded-tl-sm shadow-sm w-full leading-relaxed border border-gray-50/50 min-h-[52px] prose prose-sm max-w-none`}>
+        <div className={`${bgColor} text-gray-800 dark:text-gray-100 text-[15px] px-5 py-4 rounded-2xl rounded-tl-sm shadow-sm w-full leading-relaxed border border-gray-50/50 dark:border-gray-700/50 min-h-[52px] prose prose-sm dark:prose-invert max-w-none`}>
           {streaming && !content
             ? <span className="inline-block w-2 h-4 bg-gray-400 animate-pulse rounded" />
             : <div dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />
@@ -36,10 +36,10 @@ export function BotMessage({ name, time, avatarColor, content, meta, bgColor, qu
         </div>
         {meta && (
           <div className="flex items-center mt-2 space-x-2">
-            <div className="bg-gray-50 border border-gray-100 text-gray-400 text-xs px-2 py-1 rounded-md">
+            <div className="bg-gray-50 dark:bg-gray-700 border border-gray-100 dark:border-gray-600 text-gray-400 dark:text-gray-400 text-xs px-2 py-1 rounded-md">
               {meta}
             </div>
-            <div className="text-xs text-gray-400 hover:bg-gray-100 p-1 rounded cursor-pointer">
+            <div className="text-xs text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 p-1 rounded cursor-pointer">
               <ChevronDown size={14} />
             </div>
           </div>

--- a/src/components/Messages.jsx
+++ b/src/components/Messages.jsx
@@ -54,10 +54,10 @@ export function UserMessage({ name, time, content }) {
     <div className="flex items-start justify-end w-full">
       <div className="mr-4 flex flex-col items-end w-full max-w-3xl">
         <div className="flex items-center space-x-2 mb-1.5">
-          <span className="text-xs text-gray-400">{time}</span>
-          <span className="text-sm font-medium text-gray-700">{name}</span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">{time}</span>
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{name}</span>
         </div>
-        <div className="bg-[#FDF3EB] text-[#4A3D36] text-[15px] px-5 py-4 rounded-2xl rounded-tr-sm shadow-sm leading-relaxed border border-[#FBE3D1]/50 inline-block text-left whitespace-pre-wrap">
+        <div className="bg-[#FDF3EB] dark:bg-orange-900/30 text-[#4A3D36] dark:text-orange-100 text-[15px] px-5 py-4 rounded-2xl rounded-tr-sm shadow-sm leading-relaxed border border-[#FBE3D1]/50 dark:border-orange-800/30 inline-block text-left whitespace-pre-wrap">
           {content}
         </div>
       </div>

--- a/src/components/RightSidebar.jsx
+++ b/src/components/RightSidebar.jsx
@@ -5,23 +5,23 @@ export default function RightSidebar({ sessions, agents = [] }) {
   const agentStatusMap = sessions.reduce((acc, s) => ({ ...acc, [s.agent]: s }), {})
 
   return (
-    <div className="w-[300px] bg-[#FAFAFA] border-l border-gray-200 flex flex-col h-full flex-shrink-0 z-10 overflow-y-auto custom-scrollbar">
-      <div className="p-4 border-b border-gray-200 flex justify-between items-center">
-        <span className="text-sm font-semibold text-gray-800">当前模式: 空间</span>
-        <Settings size={18} className="text-gray-400 cursor-pointer hover:text-gray-700" />
+    <div className="w-[300px] bg-[#FAFAFA] dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex flex-col h-full flex-shrink-0 z-10 overflow-y-auto custom-scrollbar transition-colors duration-300">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+        <span className="text-sm font-semibold text-gray-800 dark:text-gray-100">当前模式: 空间</span>
+        <Settings size={18} className="text-gray-400 dark:text-gray-500 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300" />
       </div>
 
       {/* 基础设定 */}
-      <div className="p-4 border-b border-gray-200">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700">
         <div className="flex justify-between items-center mb-3 cursor-pointer group">
-          <span className="text-sm font-semibold text-gray-800">基础设定</span>
-          <ChevronUp size={16} className="text-gray-400" />
+          <span className="text-sm font-semibold text-gray-800 dark:text-gray-100">基础设定</span>
+          <ChevronUp size={16} className="text-gray-400 dark:text-gray-500" />
         </div>
         <div className="space-y-2 text-sm">
           {[['温度', '0'], ['最大 Token', '8096'], ['系统设定', '默认']].map(([k, v]) => (
             <div key={k} className="flex justify-between items-center">
-              <span className="text-gray-500">{k}</span>
-              <span className="text-gray-800 bg-gray-100 px-2 py-0.5 rounded text-xs">{v}</span>
+              <span className="text-gray-500 dark:text-gray-400">{k}</span>
+              <span className="text-gray-800 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 px-2 py-0.5 rounded text-xs">{v}</span>
             </div>
           ))}
         </div>
@@ -31,33 +31,33 @@ export default function RightSidebar({ sessions, agents = [] }) {
       <div className="p-4">
         <div className="flex justify-between items-center mb-4">
           <div className="flex items-center space-x-2">
-            <span className="text-sm font-semibold text-gray-800">Session Chain</span>
-            <Info size={14} className="text-gray-400" />
+            <span className="text-sm font-semibold text-gray-800 dark:text-gray-100">Session Chain</span>
+            <Info size={14} className="text-gray-400 dark:text-gray-500" />
           </div>
-          <span className="text-xs text-gray-500 bg-gray-200/50 px-2 py-0.5 rounded-full">
+          <span className="text-xs text-gray-500 dark:text-gray-400 bg-gray-200/50 dark:bg-gray-700 px-2 py-0.5 rounded-full">
             {sessions.length} sessions
           </span>
         </div>
 
-        <div className="space-y-3 relative before:absolute before:inset-y-4 before:left-[11px] before:w-px before:bg-gray-200">
+        <div className="space-y-3 relative before:absolute before:inset-y-4 before:left-[11px] before:w-px before:bg-gray-200 dark:before:bg-gray-700">
           {sessions.map((session, idx) => {
             const cfg = agentMap[session.agent]
             const isActive = session.status === 'ACTIVE'
             return (
               <div key={idx} className="relative pl-6">
-                <div className={`absolute left-[8px] top-2 w-2 h-2 rounded-full border border-white ${isActive ? 'bg-green-500 animate-pulse' : 'bg-gray-300'}`} />
-                <div className={`border rounded-lg p-3 ${isActive ? 'bg-white border-green-200 shadow-sm' : 'bg-gray-50 border-gray-200'}`}>
+                <div className={`absolute left-[8px] top-2 w-2 h-2 rounded-full border border-white dark:border-gray-800 ${isActive ? 'bg-green-500 animate-pulse' : 'bg-gray-300 dark:bg-gray-600'}`} />
+                <div className={`border rounded-lg p-3 ${isActive ? 'bg-white dark:bg-gray-700 border-green-200 dark:border-green-800 shadow-sm' : 'bg-gray-50 dark:bg-gray-700/50 border-gray-200 dark:border-gray-600'}`}>
                   <div className="flex justify-between items-center mb-1">
                     <span className="text-[10px] font-bold tracking-wider" style={{ color: isActive ? '#22C55E' : '#9CA3AF' }}>
                       {session.status}
                     </span>
                   </div>
-                  <div className="text-sm font-medium text-gray-800 mb-2">{cfg?.name || session.agent}</div>
+                  <div className="text-sm font-medium text-gray-800 dark:text-gray-100 mb-2">{cfg?.name || session.agent}</div>
                   <div className="flex flex-wrap gap-1">
-                    <span className="text-[11px] bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded">
+                    <span className="text-[11px] bg-gray-100 dark:bg-gray-600 text-gray-500 dark:text-gray-300 px-1.5 py-0.5 rounded">
                       {session.tokensIn}↑ {session.tokensOut}↓
                     </span>
-                    <span className="text-[11px] bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded">
+                    <span className="text-[11px] bg-gray-100 dark:bg-gray-600 text-gray-500 dark:text-gray-300 px-1.5 py-0.5 rounded">
                       {cfg?.modelLabel}
                     </span>
                   </div>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react'
-import { Menu, Search, Edit3, BarChart2, ListTodo, Home, Book, Calendar, Settings, ChevronDown, Trash2, X, Check } from 'lucide-react'
+import { Menu, Search, Edit3, BarChart2, ListTodo, Home, Book, Calendar, Settings, ChevronDown, Trash2, X, Check, Sun, Moon } from 'lucide-react'
 import CatIcon from './CatIcon'
 
-export default function Sidebar({ conversations, activeId, onOpenNewChat, onSwitch, onOpenCatNest, activePage, agents = [], onDelete, onConfirmDelete, isConfirmRequired }) {
+export default function Sidebar({ conversations, activeId, onOpenNewChat, onSwitch, onOpenCatNest, activePage, agents = [], isDark, onToggleTheme, onDelete, onConfirmDelete, isConfirmRequired }) {
+  const [isAnimating, setIsAnimating] = useState(false)
   const agentMap = agents.reduce((acc, a) => { acc[a.id] = a; return acc }, {})
   const [pendingDeleteId, setPendingDeleteId] = useState(null)
   useEffect(() => {
@@ -19,116 +20,149 @@ export default function Sidebar({ conversations, activeId, onOpenNewChat, onSwit
     { icon: <Calendar size={16} />, label: '计划板' },
   ]
 
+  const handleToggle = () => {
+    if (isAnimating) return
+    setIsAnimating(true)
+    onToggleTheme()
+  }
+
   return (
-    <div className="w-[260px] flex flex-col border-r border-gray-200 bg-[#FAFAFA] h-full flex-shrink-0 z-10">
-      <div className="flex items-center justify-between p-4 text-gray-500">
-        <Menu size={20} className="cursor-pointer hover:text-gray-800" />
-        <div className="flex space-x-3">
-          <Search size={20} className="cursor-pointer hover:text-gray-800" />
-          <Edit3 size={20} className="cursor-pointer text-[#D87C65] hover:text-[#C56A55]" onClick={onOpenNewChat} />
-        </div>
-      </div>
-
-      <div className="flex flex-col px-2 space-y-0.5">
-        {navItems.map((item, idx) => {
-          const isNew = item.label === '发起新对话'
-          const isActive = item.page && item.page === activePage
-          return (
-            <div
-              key={idx}
-              onClick={item.action}
-              className={`flex items-center space-x-3 px-3 py-2 text-sm rounded-lg cursor-pointer transition-colors ${
-                isNew ? 'text-[#D87C65] hover:bg-orange-50/50' :
-                isActive ? 'bg-[#EAEAEA] text-gray-900' :
-                'text-gray-700 hover:bg-gray-100'
-              }`}
+    <>
+      <style>{`
+        @keyframes bounce-toggle {
+          0%   { transform: scale(1) rotate(0deg); }
+          25%  { transform: scale(1.4) rotate(-20deg); }
+          50%  { transform: scale(0.8) rotate(15deg); }
+          70%  { transform: scale(1.15) rotate(-8deg); }
+          85%  { transform: scale(0.95) rotate(4deg); }
+          100% { transform: scale(1) rotate(0deg); }
+        }
+        .animate-bounce-toggle {
+          animation: bounce-toggle 0.45s cubic-bezier(0.36, 0.07, 0.19, 0.97) forwards;
+        }
+      `}</style>
+      <div className="w-[260px] flex flex-col border-r border-gray-200 dark:border-gray-700 bg-[#FAFAFA] dark:bg-gray-800 h-full flex-shrink-0 z-10 transition-colors duration-300">
+        <div className="flex items-center justify-between p-4 text-gray-500 dark:text-gray-400">
+          <Menu size={20} className="cursor-pointer hover:text-gray-800 dark:hover:text-gray-100" />
+          <div className="flex items-center space-x-3">
+            <Search size={20} className="cursor-pointer hover:text-gray-800 dark:hover:text-gray-100" />
+            <Edit3 size={20} className="cursor-pointer text-[#D87C65] hover:text-[#C56A55]" onClick={onOpenNewChat} />
+            <button
+              onClick={handleToggle}
+              onAnimationEnd={() => setIsAnimating(false)}
+              className={`cursor-pointer hover:text-gray-800 dark:hover:text-gray-100 focus:outline-none ${isAnimating ? 'animate-bounce-toggle' : ''}`}
+              aria-label="切换深色模式"
             >
-              <span className={isNew ? 'text-[#D87C65]' : isActive ? 'text-gray-700' : 'text-gray-500'}>{item.icon}</span>
-              <span className={isNew ? 'font-medium' : isActive ? 'font-medium' : ''}>{item.label}</span>
-            </div>
-          )
-        })}
-      </div>
-
-      <div className="flex-1 overflow-y-auto mt-4 px-2 custom-scrollbar">
-        <div className="flex items-center text-xs text-gray-400 px-3 mb-2">
-          <ChevronDown size={14} className="mr-1" />
-          <span>你的聊天</span>
+              {isDark ? <Sun size={20} /> : <Moon size={20} />}
+            </button>
+          </div>
         </div>
-        <div className="space-y-0.5">
-          {conversations.length === 0 && (
-            <div className="px-3 py-4 text-xs text-gray-400 text-center">暂无对话，点击上方发起新对话</div>
-          )}
-          {conversations.map((conv) => (
-            <div
-              key={conv.id}
-              onClick={() => { if (pendingDeleteId !== conv.id) onSwitch(conv.id) }}
-              className={`group relative flex flex-col px-3 py-2 rounded-lg cursor-pointer transition-colors ${conv.id === activeId ? 'bg-[#EAEAEA] text-gray-900' : 'hover:bg-gray-100 text-gray-700'}`}
-            >
-              {pendingDeleteId === conv.id ? (
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-gray-500">确认删除？</span>
-                  <div className="flex space-x-1">
-                    <button
-                      onClick={e => { e.stopPropagation(); onConfirmDelete(conv.id); setPendingDeleteId(null) }}
-                      className="p-1 text-red-500 hover:bg-red-50 rounded"
-                      aria-label="确认删除"
-                    >
-                      <Check size={13} />
-                    </button>
-                    <button
-                      onClick={e => { e.stopPropagation(); setPendingDeleteId(null) }}
-                      className="p-1 text-gray-400 hover:bg-gray-200 rounded"
-                      aria-label="取消删除"
-                    >
-                      <X size={13} />
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                <>
+
+        <div className="flex flex-col px-2 space-y-0.5">
+          {navItems.map((item, idx) => {
+            const isNew = item.label === '发起新对话'
+            const isActive = item.page && item.page === activePage
+            return (
+              <div
+                key={idx}
+                onClick={item.action}
+                className={`flex items-center space-x-3 px-3 py-2 text-sm rounded-lg cursor-pointer transition-colors ${
+                  isNew ? 'text-[#D87C65] hover:bg-orange-50/50 dark:hover:bg-orange-900/20' :
+                  isActive ? 'bg-[#EAEAEA] dark:bg-gray-700 text-gray-900 dark:text-gray-100' :
+                  'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                }`}
+              >
+                <span className={isNew ? 'text-[#D87C65]' : isActive ? 'text-gray-700 dark:text-gray-300' : 'text-gray-500 dark:text-gray-400'}>{item.icon}</span>
+                <span className={isNew ? 'font-medium' : isActive ? 'font-medium' : ''}>{item.label}</span>
+              </div>
+            )
+          })}
+        </div>
+
+        <div className="flex-1 overflow-y-auto mt-4 px-2 custom-scrollbar">
+          <div className="flex items-center text-xs text-gray-400 dark:text-gray-500 px-3 mb-2">
+            <ChevronDown size={14} className="mr-1" />
+            <span>你的聊天</span>
+          </div>
+          <div className="space-y-0.5">
+            {conversations.length === 0 && (
+              <div className="px-3 py-4 text-xs text-gray-400 dark:text-gray-500 text-center">暂无对话，点击上方发起新对话</div>
+            )}
+            {conversations.map((conv) => (
+              <div
+                key={conv.id}
+                onClick={() => { if (pendingDeleteId !== conv.id) onSwitch(conv.id) }}
+                className={`group relative flex flex-col px-3 py-2 rounded-lg cursor-pointer transition-colors ${
+                  conv.id === activeId
+                    ? 'bg-[#EAEAEA] dark:bg-gray-700 text-gray-900 dark:text-gray-100'
+                    : 'hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300'
+                }`}
+              >
+                {pendingDeleteId === conv.id ? (
                   <div className="flex items-center justify-between">
-                    <span className="text-sm truncate pr-2 font-medium">{conv.label}</span>
-                    <div className="flex items-center space-x-1">
-                      <span className="text-xs text-gray-400 shrink-0">
-                        {new Date(conv.createdAt).toLocaleTimeString('zh', { hour: '2-digit', minute: '2-digit' })}
-                      </span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">确认删除？</span>
+                    <div className="flex space-x-1">
                       <button
-                        onClick={e => {
-                          e.stopPropagation()
-                          if (isConfirmRequired()) {
-                            setPendingDeleteId(conv.id)
-                          } else {
-                            onDelete(conv.id)
-                          }
-                        }}
-                        className="opacity-0 group-hover:opacity-100 p-1 text-gray-400 hover:text-red-500 hover:bg-white/60 rounded transition-opacity"
-                        aria-label={`删除会话 ${conv.label}`}
+                        onClick={e => { e.stopPropagation(); onConfirmDelete(conv.id); setPendingDeleteId(null) }}
+                        className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
+                        aria-label="确认删除"
                       >
-                        <Trash2 size={13} />
+                        <Check size={13} />
+                      </button>
+                      <button
+                        onClick={e => { e.stopPropagation(); setPendingDeleteId(null) }}
+                        className="p-1 text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600 rounded"
+                        aria-label="取消删除"
+                      >
+                        <X size={13} />
                       </button>
                     </div>
                   </div>
-                  <div className="flex mt-1.5 space-x-1">
-                    {conv.agents.map((agentType, i) => (
-                      <div key={i} className={`w-4 h-4 rounded-full ${agentMap[agentType]?.avatarColor || 'bg-gray-300'} border border-white flex items-center justify-center`}>
-                        <CatIcon size={10} color="white" />
+                ) : (
+                  <>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm truncate pr-2 font-medium">{conv.label}</span>
+                      <div className="flex items-center space-x-1">
+                        <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+                          {new Date(conv.createdAt).toLocaleTimeString('zh', { hour: '2-digit', minute: '2-digit' })}
+                        </span>
+                        <button
+                          onClick={e => {
+                            e.stopPropagation()
+                            if (isConfirmRequired()) {
+                              setPendingDeleteId(conv.id)
+                            } else {
+                              onDelete(conv.id)
+                            }
+                          }}
+                          className="opacity-0 group-hover:opacity-100 p-1 text-gray-400 hover:text-red-500 hover:bg-white/60 dark:hover:bg-gray-600 rounded transition-opacity"
+                          aria-label={`删除会话 ${conv.label}`}
+                        >
+                          <Trash2 size={13} />
+                        </button>
                       </div>
-                    ))}
-                  </div>
-                </>
-              )}
-            </div>
-          ))}
+                    </div>
+                    <div className="flex mt-1.5 space-x-1">
+                      {conv.agents.map((agentType, i) => (
+                        <div key={i} className={`w-4 h-4 rounded-full ${agentMap[agentType]?.avatarColor || 'bg-gray-300'} border border-white dark:border-gray-800 flex items-center justify-center`}>
+                          <CatIcon size={10} color="white" />
+                        </div>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
 
-      <div className="p-4 border-t border-gray-200">
-        <div className="flex items-center space-x-3 text-sm text-gray-600 hover:text-gray-900 cursor-pointer">
-          <Settings size={18} />
-          <span>设置</span>
+        <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+          <div className="flex items-center space-x-3 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 cursor-pointer">
+            <Settings size={18} />
+            <span>设置</span>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/store/themeStore.js
+++ b/src/store/themeStore.js
@@ -1,11 +1,19 @@
 import { useState, useEffect } from 'react'
 
+function getInitialDark() {
+  const stored = localStorage.getItem('cat-cafe:theme')
+  const isDark = stored ? stored === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches
+  // 同步设置，避免首屏闪烁
+  if (isDark) {
+    document.documentElement.classList.add('dark')
+  } else {
+    document.documentElement.classList.remove('dark')
+  }
+  return isDark
+}
+
 export function useTheme() {
-  const [isDark, setIsDark] = useState(() => {
-    const stored = localStorage.getItem('cat-cafe:theme')
-    if (stored) return stored === 'dark'
-    return window.matchMedia('(prefers-color-scheme: dark)').matches
-  })
+  const [isDark, setIsDark] = useState(getInitialDark)
 
   useEffect(() => {
     const root = document.documentElement

--- a/src/store/themeStore.js
+++ b/src/store/themeStore.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react'
+
+export function useTheme() {
+  const [isDark, setIsDark] = useState(() => {
+    const stored = localStorage.getItem('cat-cafe:theme')
+    if (stored) return stored === 'dark'
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (isDark) {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    localStorage.setItem('cat-cafe:theme', isDark ? 'dark' : 'light')
+  }, [isDark])
+
+  const toggle = () => setIsDark(d => !d)
+
+  return { isDark, toggle }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,jsx}'],
+  darkMode: 'class',
   theme: { extend: {} },
   plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
## Changes

- `tailwind.config.js`: 启用 `darkMode: 'class'`
- `src/store/themeStore.js`: 新增 `useTheme` hook，localStorage 持久化，初始值读取系统偏好
- `src/App.jsx`: 集成 `useTheme`，根 div 加 `dark:bg-gray-900` + `transition-colors duration-300`，传 `isDark`/`onToggleTheme` 给 Sidebar
- `src/components/Sidebar.jsx`: 顶部 header 加 Sun/Moon 切换按钮，Q 弹 keyframe 动效（scale + rotate），全组件 `dark:` 颜色
- `src/components/MainChatArea.jsx`: 全组件 `dark:` 颜色
- `src/components/ChatInput.jsx`: 全组件 `dark:` 颜色（面板、输入框、按钮）
- `src/components/RightSidebar.jsx`: 全组件 `dark:` 颜色

## 行为

- 点击 Sidebar 顶部 Moon/Sun 图标切换深色/浅色模式
- 切换时图标触发 Q 弹动效（scale 1→1.4→0.8→1.15→1，rotate 0→-20→15→-8→0deg）
- 偏好持久化到 `localStorage`（key: `cat-cafe:theme`），刷新保持
- 初始值读取系统 `prefers-color-scheme`
- 所有主要界面区域支持深色模式

Closes #27