### PR TITLE
fix: override dynamic bgColor with dark:bg-gray-700 in dark mode (issue #27)

### DIFF
--- a/src/components/CatNest.jsx
+++ b/src/components/CatNest.jsx
@@ -152,7 +152,7 @@ export default function CatNest({ agents, onCreate, onUpdate, onDelete }) {
                       onCancel={() => setEditingId(null)}
                     />
                   ) : (
-                    <div className={`${agent.bgColor} border border-gray-100 dark:border-gray-700 rounded-xl p-4 flex items-start justify-between`}>
+                    <div className={`${agent.bgColor} dark:bg-gray-700 border border-gray-100 dark:border-gray-700 rounded-xl p-4 flex items-start justify-between`}>
                       <div className="flex items-start space-x-3">
                         <div className={`w-9 h-9 rounded-full ${agent.avatarColor} flex items-center justify-center shrink-0 shadow-sm`}>
                           <CatIcon size={20} color="white" />

--- a/src/components/Messages.jsx
+++ b/src/components/Messages.jsx
@@ -28,7 +28,7 @@ export function BotMessage({ name, time, avatarColor, content, meta, bgColor, qu
             <p className="text-[13px] text-gray-600 dark:text-gray-300 line-clamp-2 leading-relaxed">{quote.text}</p>
           </div>
         )}
-        <div className={`${bgColor} text-gray-800 dark:text-gray-100 text-[15px] px-5 py-4 rounded-2xl rounded-tl-sm shadow-sm w-full leading-relaxed border border-gray-50/50 dark:border-gray-700/50 min-h-[52px] prose prose-sm dark:prose-invert max-w-none`}>
+        <div className={`${bgColor} dark:bg-gray-700 text-gray-800 dark:text-gray-100 text-[15px] px-5 py-4 rounded-2xl rounded-tl-sm shadow-sm w-full leading-relaxed border border-gray-50/50 dark:border-gray-700/50 min-h-[52px] prose prose-sm dark:prose-invert max-w-none`}>
           {streaming && !content
             ? <span className="inline-block w-2 h-4 bg-gray-400 animate-pulse rounded" />
             : <div dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }} />


### PR DESCRIPTION
## 问题

`BotMessage` 气泡和 CatNest agent 卡片的底色来自 `agentStore.js` 中的固定浅色 hex 值（如 `bg-[#EAE4F2]`），Tailwind 无法为动态 class 生成 `dark:` 变体，导致 dark 模式下这两处仍显示亮色块。

## 修复

在两处动态 `bgColor` 后追加 `dark:bg-gray-700`，dark 模式下统一覆盖为深色底，浅色模式保持原有彩色气泡不变。

- `src/components/Messages.jsx`: `BotMessage` 气泡加 `dark:bg-gray-700`
- `src/components/CatNest.jsx`: agent 卡片加 `dark:bg-gray-700`

Closes #27