### PR TITLE
feat(bridge): replace API-backed claude provider with Claude Code CLI backend (close #33)

### DIFF
--- a/bridge/providers/claude.js
+++ b/bridge/providers/claude.js
@@ -19,26 +19,24 @@ export function isAvailable() {
 
 export async function* stream({ messages, model, systemPrompt, signal, apiKey, baseUrl }) {
   const lastUserIdx = messages.findLastIndex(m => m.role === 'user')
-  const lastUser = messages[lastUserIdx]
-  if (!lastUser) {
+  if (lastUserIdx === -1) {
     yield { type: 'error', message: '没有用户消息' }
     return
   }
 
-  // 历史拼接（同 codex.js 模式）
-  const history = messages.slice(0, lastUserIdx)
-  const prefix = history.length
-    ? history.map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${
-        Array.isArray(m.content)
-          ? m.content.filter(b => b.type === 'text').map(b => b.text).join('')
-          : m.content
-      }`).join('\n') + '\n\nUser: '
+  // 历史拼接：保留完整消息序列（含 lastUser 之后的 assistant turns，支持 @mention 链式触发）
+  const extractText = (content) => Array.isArray(content)
+    ? content.filter(b => b.type === 'text').map(b => b.text).join('')
+    : content
+
+  const prefixMessages = messages.slice(0, -1)
+  const lastMessage = messages[messages.length - 1]
+
+  const prefix = prefixMessages.length
+    ? prefixMessages.map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${extractText(m.content)}`).join('\n') + '\n\n'
     : ''
-  const prompt = prefix + (
-    Array.isArray(lastUser.content)
-      ? lastUser.content.filter(b => b.type === 'text').map(b => b.text).join('')
-      : lastUser.content
-  )
+  const finalRole = lastMessage.role === 'user' ? 'User' : 'Assistant'
+  const prompt = prefix + `${finalRole}: ${extractText(lastMessage.content)}`
 
   const args = ['--print', '--output-format', 'stream-json', '--verbose']
   if (model) args.push('--model', model)
@@ -107,8 +105,14 @@ export async function* stream({ messages, model, systemPrompt, signal, apiKey, b
     closed = true
   })
 
-  child.on('close', () => {
-    if (!signal?.aborted && !terminated) push({ type: 'done' })
+  child.on('close', (code) => {
+    if (!signal?.aborted && !terminated) {
+      if (code !== 0) {
+        push({ type: 'error', message: `claude CLI exited with code ${code}` })
+      } else {
+        push({ type: 'done' })
+      }
+    }
     closed = true
     emitter.emit('data')
   })

--- a/bridge/providers/claude.js
+++ b/bridge/providers/claude.js
@@ -1,46 +1,119 @@
 /**
- * Claude provider adapter
- * 输入: { messages, model, systemPrompt, apiKey?, baseUrl? }
+ * Claude Code CLI provider adapter
+ * 输入: { messages, model, systemPrompt, signal, apiKey?, baseUrl? }
  * 输出: async generator，yield { type, ... }
+ *
+ * CLI flags: claude --print --output-format stream-json --verbose
+ * per-agent auth via ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL env vars
  */
-import Anthropic from '@anthropic-ai/sdk'
+import { spawn } from 'child_process'
+import { EventEmitter } from 'events'
 
 export const id = 'claudecode'
 
+const CLAUDE_EXE = process.env.CLAUDE_EXE_PATH || 'claude'
+
 export function isAvailable() {
-  return !!process.env.CLAUDE_API_KEY
+  return true // claude CLI assumed on PATH; spawn error handled at runtime
 }
 
-export async function* stream({ messages, model = 'claude-sonnet-4-6', systemPrompt, signal, apiKey, baseUrl }) {
-  const resolvedKey = apiKey || process.env.CLAUDE_API_KEY
-  if (!resolvedKey) {
-    yield { type: 'error', message: 'CLAUDE_API_KEY not set in bridge environment' }
+export async function* stream({ messages, model, systemPrompt, signal, apiKey, baseUrl }) {
+  const lastUserIdx = messages.findLastIndex(m => m.role === 'user')
+  const lastUser = messages[lastUserIdx]
+  if (!lastUser) {
+    yield { type: 'error', message: '没有用户消息' }
     return
   }
 
-  const clientOpts = { apiKey: resolvedKey }
-  if (baseUrl) clientOpts.baseURL = baseUrl
-  const client = new Anthropic(clientOpts)
+  // 历史拼接（同 codex.js 模式）
+  const history = messages.slice(0, lastUserIdx)
+  const prefix = history.length
+    ? history.map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${
+        Array.isArray(m.content)
+          ? m.content.filter(b => b.type === 'text').map(b => b.text).join('')
+          : m.content
+      }`).join('\n') + '\n\nUser: '
+    : ''
+  const prompt = prefix + (
+    Array.isArray(lastUser.content)
+      ? lastUser.content.filter(b => b.type === 'text').map(b => b.text).join('')
+      : lastUser.content
+  )
 
-  const params = { model, max_tokens: 8096, messages }
-  if (systemPrompt) params.system = systemPrompt
+  const args = ['--print', '--output-format', 'stream-json', '--verbose']
+  if (model) args.push('--model', model)
+  if (systemPrompt) args.push('--system-prompt', systemPrompt)
+  args.push(prompt)
 
-  const anthropicStream = client.messages.stream(params)
+  // per-agent 环境变量注入
+  const env = { ...process.env }
+  if (apiKey)  env.ANTHROPIC_API_KEY  = apiKey
+  if (baseUrl) env.ANTHROPIC_BASE_URL = baseUrl
 
-  signal?.addEventListener('abort', () => anthropicStream.abort())
+  const child = spawn(CLAUDE_EXE, args, { env })
+  signal?.addEventListener('abort', () => { if (!child.killed) child.kill() })
 
-  try {
-    for await (const event of anthropicStream) {
-      if (signal?.aborted) break
-      if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
-        yield { type: 'chunk', text: event.delta.text }
-      }
-      if (event.type === 'message_delta' && event.usage) {
-        yield { type: 'usage', usage: event.usage }
-      }
+  const emitter = new EventEmitter()
+  const queue = []
+  let closed = false
+  let terminated = false
+
+  const push = (event) => { queue.push(event); emitter.emit('data') }
+
+  let buffer = ''
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk.toString()
+    const lines = buffer.split('\n')
+    buffer = lines.pop()
+    for (const line of lines) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      try {
+        const json = JSON.parse(trimmed)
+
+        // text chunks from assistant turns
+        if (json.type === 'assistant' && json.message?.content) {
+          for (const block of json.message.content) {
+            if (block.type === 'text' && block.text) {
+              push({ type: 'chunk', text: block.text })
+            }
+            // tool_use blocks: ignored, CLI handles execution internally
+          }
+        }
+
+        // terminal event
+        if (json.type === 'result') {
+          terminated = true
+          if (json.is_error) {
+            push({ type: 'error', message: json.result })
+          } else {
+            if (json.usage) push({ type: 'usage', usage: json.usage })
+            push({ type: 'done' })
+          }
+        }
+
+        // type: "user" (tool_result feedback) and type: "system": ignored
+      } catch { /* 忽略非 JSON 行 */ }
     }
-    if (!signal?.aborted) yield { type: 'done' }
-  } catch (err) {
-    if (!signal?.aborted) yield { type: 'error', message: err.message, status: err.status ?? err.statusCode }
+  })
+
+  child.stderr.on('data', (chunk) => console.error('[claude stderr]', chunk.toString()))
+
+  child.on('error', (err) => {
+    push({ type: 'error', message: err.message })
+    closed = true
+    emitter.emit('data')
+  })
+
+  child.on('close', () => {
+    if (!signal?.aborted && !terminated) push({ type: 'done' })
+    closed = true
+    emitter.emit('data')
+  })
+
+  while (true) {
+    if (queue.length > 0) yield queue.shift()
+    else if (closed) break
+    else await new Promise(r => emitter.once('data', r))
   }
 }

--- a/bridge/providers/claude.js
+++ b/bridge/providers/claude.js
@@ -58,7 +58,10 @@ export async function* stream({ messages, model, systemPrompt, signal, apiKey, b
   let closed = false
   let terminated = false
 
-  const push = (event) => { queue.push(event); emitter.emit('data') }
+  const push = (event) => {
+    queue.push(event)
+    emitter.emit('data')
+  }
 
   let buffer = ''
   child.stdout.on('data', (chunk) => {
@@ -102,7 +105,6 @@ export async function* stream({ messages, model, systemPrompt, signal, apiKey, b
   child.on('error', (err) => {
     push({ type: 'error', message: err.message })
     closed = true
-    emitter.emit('data')
   })
 
   child.on('close', () => {
@@ -112,8 +114,12 @@ export async function* stream({ messages, model, systemPrompt, signal, apiKey, b
   })
 
   while (true) {
-    if (queue.length > 0) yield queue.shift()
-    else if (closed) break
-    else await new Promise(r => emitter.once('data', r))
+    if (queue.length > 0) {
+      yield queue.shift()
+    } else if (closed) {
+      break
+    } else {
+      await new Promise(resolve => emitter.once('data', resolve))
+    }
   }
 }


### PR DESCRIPTION
## What changed

`bridge/providers/claude.js` 从 `@anthropic-ai/sdk` Messages API streaming 改为 spawn `claude` CLI 进程，与 `bridge/providers/codex.js` 的本地 CLI 执行模型对齐。

核心变化：
- 移除 `@anthropic-ai/sdk` import，改为 `child_process.spawn`
- CLI flags：`claude --print --output-format stream-json --verbose`
- per-agent auth 通过环境变量注入：`ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL`
- CLI JSON 事件映射到 bridge contract（`chunk` / `usage` / `done` / `error`）
- 历史消息拼接处理 Array content（比 codex.js 更健壮）
- `terminated` 标志防止 `close` 事件重复发送 `done`

## Why

issue #33：provider 命名为 `claudecode` 但实现是 API wrapper，与 codex.js 的 CLI 执行模型不一致，不满足本地 agent 架构愿景。

## What was NOT changed

- `bridge/gateway.js`：provider contract 不变，无需修改
- `bridge/server.js`：旧 `/claude/stream` 路由保留（向后兼容，独立 issue 处理）
- 前端、Redis schema、其他 provider 均未改动

## Risks

- **UX 差异**：CLI `--print` 模式全文一次性返回，无打字机效果（`assistant` 事件含完整文本，非逐字符 `text_delta`）
- **CLI 依赖**：`claude` 需在 PATH 或通过 `CLAUDE_EXE_PATH` 环境变量指定
- **工具调用**：CLI 内部自动执行工具（Bash/Read 等），在 bridge server 文件系统上运行，生产环境需评估权限边界
- **`@anthropic-ai/sdk` 未完全移除**：旧路由 `/claude/stream` 仍依赖 SDK，需另开 issue 处理

## Validation steps

1. 确认 `claude` CLI 在 PATH 或设置 `CLAUDE_EXE_PATH`
2. 启动 bridge：`node bridge/server.js`
3. 发送测试请求：
```bash
curl -s -N -X POST http://localhost:4891/gateway/stream \
  -H "Content-Type: application/json" \
  -H "X-Local-Token: <token>" \
  -d '{"provider":"claudecode","messages":[{"role":"user","content":"hello"}]}'
```
4. 预期：收到 `{"type":"chunk",...}` 事件，最后 `{"type":"done"}`

## Linked issue

Closes #33
