### PR TITLE
fix(bridge): close child.stdin to unblock Claude CLI pipe mode (close #36)

### DIFF
--- a/bridge/providers/claude.js
+++ b/bridge/providers/claude.js
@@ -49,6 +49,7 @@ export async function* stream({ messages, model, systemPrompt, signal, apiKey, b
   if (baseUrl) env.ANTHROPIC_BASE_URL = baseUrl
 
   const child = spawn(CLAUDE_EXE, args, { env })
+  child.stdin.end() // CLI reads prompt from args; close stdin immediately to unblock pipe mode
   signal?.addEventListener('abort', () => { if (!child.killed) child.kill() })
 
   const emitter = new EventEmitter()


### PR DESCRIPTION
## What changed

`bridge/providers/claude.js:52` — spawn 后立即调用 `child.stdin.end()`，一行改动。

## Why

issue #36：Node `spawn()` 默认 pipe stdio，Claude Code CLI 在 pipe 模式下等待 stdin EOF 才开始处理。PR #34 合并后 `child.stdin` 从未关闭，导致所有 Claude 请求挂起 60s 后 gateway timeout，Claude agent 实际不可用。

直接 shell 调用正常（shell 不 pipe stdin），Node spawn 挂起，`child.stdin.end()` 后立即恢复正常——根因已通过 issue #36 中的本地复现验证。

## What was NOT changed

其余逻辑、事件映射、abort 处理均未改动。

## Risks

极低。`claude --print` 模式从 args 读取 prompt，不依赖 stdin，关闭 stdin 无副作用。

## Validation steps

1. 启动 bridge：`node bridge/server.js`
2. 发送请求：
```bash
curl -s -N -X POST http://localhost:4891/gateway/stream \
  -H "Content-Type: application/json" \
  -H "X-Local-Token: <token>" \
  -d '{"provider":"claudecode","messages":[{"role":"user","content":"hello"}]}'
```
3. 预期：~10s 内收到 `{"type":"chunk",...}`，最后 `{"type":"done"}`，不再 timeout。

## Linked issue

Closes #36
