### PR TITLE
docs: sync CLAUDE.md and README.md with Claude CLI architecture (close #35)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,5 @@
-# Bridge 侧 URL（前端连接 bridge 用）
+# Vite 前端变量（由 Vite 读取，需以 VITE_ 开头）
 VITE_CODEX_BRIDGE_URL=http://localhost:4891
 
-# 内置 Claude agent 默认使用本地 Claude Code CLI 登录态（claude login）
-# 无需配置 API Key；自定义 Claude-compatible agent 的 apiKey 在 UI 中单独配置，存 Redis，不进此文件
-
-# Claude CLI 可执行文件路径（可选，默认使用 PATH 中的 claude）
-# CLAUDE_EXE_PATH=C:\path\to\claude.exe
-
-# Codex CLI 可执行文件路径（可选，覆盖 bridge/server.js 中的默认路径）
-# CODEX_EXE_PATH=C:\path\to\codex.exe
-
-# 旧路由 /claude/stream 专用（已废弃，仅向后兼容保留）
-# CLAUDE_API_KEY=sk-ant-xxxxxxxx
-
-# Gateway policy 配置（可选，以下为默认值）
-# GATEWAY_TIMEOUT_MS=60000       # 单次请求超时（毫秒）
-# GATEWAY_MAX_RETRIES=2          # 最大重试次数（仅限流/网络错误）
-# GATEWAY_RETRY_BASE_MS=500      # 重试基础等待时间（指数退避）
-# GATEWAY_MAX_CONCURRENCY=10     # 最大并发请求数
+# Bridge 侧变量通过 shell 环境变量传入，不在此文件中配置
+# 参见 README.md 配置章节

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,17 @@
-# Bridge 侧 Claude API Key（只在 bridge/server.js 中读取，不进前端 bundle）
-CLAUDE_API_KEY=your_api_key_here
-
-# Codex CLI 本地代理地址
+# Bridge 侧 URL（前端连接 bridge 用）
 VITE_CODEX_BRIDGE_URL=http://localhost:4891
 
-# Codex 可执行文件路径（可选，覆盖 bridge/server.js 中的默认路径）
+# 内置 Claude agent 默认使用本地 Claude Code CLI 登录态（claude login）
+# 无需配置 API Key；自定义 Claude-compatible agent 的 apiKey 在 UI 中单独配置，存 Redis，不进此文件
+
+# Claude CLI 可执行文件路径（可选，默认使用 PATH 中的 claude）
+# CLAUDE_EXE_PATH=C:\path\to\claude.exe
+
+# Codex CLI 可执行文件路径（可选，覆盖 bridge/server.js 中的默认路径）
 # CODEX_EXE_PATH=C:\path\to\codex.exe
+
+# 旧路由 /claude/stream 专用（已废弃，仅向后兼容保留）
+# CLAUDE_API_KEY=sk-ant-xxxxxxxx
 
 # Gateway policy 配置（可选，以下为默认值）
 # GATEWAY_TIMEOUT_MS=60000       # 单次请求超时（毫秒）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,10 @@
 ## 架构概览
 
 ```
-前端 (Vite + React + Tailwind)  ←→  bridge/server.js (Express :4891)  ←→  Redis / codex.exe / Anthropic API
+前端 (Vite + React + Tailwind)  ←→  bridge/server.js (Express :4891)  ←→  Redis / codex.exe / Claude Code CLI
                                          └── gateway.js (统一 provider 路由)
-                                               ├── providers/claude.js
-                                               └── providers/codex.js
+                                               ├── providers/claude.js  → Claude Code CLI（本地子进程）
+                                               └── providers/codex.js   → codex.exe（本地子进程）
 ```
 
 - 前端不直连任何 AI API，全部经由 bridge 中转
@@ -31,12 +31,13 @@
 | 依赖 | 说明 |
 |------|------|
 | Redis | WSL 内运行，`wsl redis-server --daemonize yes`，监听 `127.0.0.1:6379` |
-| codex.exe | 路径由 `CODEX_EXE_PATH` 环境变量指定，或修改 `bridge/server.js:38` |
-| `.env` | 复制 `.env.example`，填入 `CLAUDE_API_KEY`（bridge 侧，不进前端） |
+| Claude Code CLI | `claude` 命令需在 PATH，或通过 `CLAUDE_EXE_PATH` 环境变量指定；默认使用本地登录态（`claude login`），per-agent 可通过 Redis 中的 `apiKey`/`baseUrl` 覆盖 |
+| codex.exe | 路径由 `CODEX_EXE_PATH` 环境变量指定 |
+| `.env` | 复制 `.env.example`；内置 Claude agent 默认走本地 CLI 登录态，无需 `CLAUDE_API_KEY` |
 
 启动：`npm run dev`（同时启动 bridge + Vite）
 
-## 已知 P1 问题状态
+## 已知问题状态
 
 | # | 问题 | 状态 |
 |---|------|------|
@@ -50,6 +51,8 @@
 | #17 | 自定义 Agent 无法配置 baseUrl / apiKey | ✅ 已修复（per-agent 后端连接支持） |
 | #18 | bridge 不可用时无明确错误提示 | ✅ 已修复（全屏错误横幅 + 重试） |
 | #23 | @mention token 泄漏进 provider prompt | ✅ 已修复（stripMentions） |
+| #33 | claude provider 实现与本地 agent 架构不符 | ✅ 已修复（CLI 后端替换） |
+| #36 | Claude CLI provider stdin 未关闭导致所有请求 timeout | ✅ 已修复（child.stdin.end()） |
 | #16 | @mention 链式调用无循环保护 | 🔴 待修复 |
 
 ## 演进路径
@@ -63,9 +66,11 @@
   per-agent 自定义后端连接（baseUrl / apiKey，仅 Claude-compatible provider）✓
   bridge 不可用错误提示 + 重试 ✓
   @mention token 不泄漏进 provider prompt ✓
+  Claude provider 替换为本地 Claude Code CLI 后端 ✓
 
 下一步
   @mention 链式调用循环保护（issue #16）
+  内置 agent e2e smoke test（issue #37）
   Agent 工作目录隔离（每会话独立 cwd）
   消息导出（Markdown/JSON）
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 一句话定位
 
-把多个智能体像小型研发团队一样协作落到工程现实：**可视化协作、@mention 路由、会话持久化、可在浏览器中一键启动**。当前内置 Claude 和 Codex 两个 provider，Claude-compatible backend 支持为每个自定义 Agent 配置独立的 baseUrl / apiKey；Codex provider 通过本地 CLI 调用，不支持自定义凭据。
+把多个智能体像小型研发团队一样协作落到工程现实：**可视化协作、@mention 路由、会话持久化、可在浏览器中一键启动**。当前内置 Claude 和 Codex 两个 provider，Claude 内置 agent 通过本地 Claude Code CLI 运行；Claude-compatible backend 支持为每个自定义 Agent 配置独立的 baseUrl / apiKey；Codex provider 通过本地 CLI 调用，不支持自定义凭据。
 
 ---
 
@@ -19,7 +19,7 @@
 | 多 Agent 并发对话 | 同一条消息同时发给多个 AI，并排流式展示回复 |
 | @mention 路由 | AI 回复中 `@name` 自动触发目标 Agent 响应，支持链式协作 |
 | 会话持久化 | Redis 存储全量会话，刷新不丢失，UUID 防冲突 |
-| 自定义 Agent | 可配置模型 ID、System Prompt；Claude provider 额外支持 baseUrl / apiKey（仅存 bridge Redis，不回传前端）；Codex provider 通过本地 CLI 调用，不支持自定义凭据 |
+| 自定义 Agent | 可配置模型 ID、System Prompt；Claude provider 额外支持 baseUrl / apiKey（仅存 bridge Redis，不回传前端），留空则使用本地 Claude Code CLI 登录态；Codex provider 通过本地 CLI 调用，不支持自定义凭据 |
 | 流式输出 + 停止 | 实时显示 token，支持随时中断所有 Agent |
 | Token 统计 | 每条回复显示 input/output token 用量 |
 | Bridge 中转 | 前端不直连 AI API，全部经由本地 Express bridge |
@@ -43,8 +43,8 @@ bridge/server.js  (Express :4891)
   cat-cafe:conversations    ↕              ↕
   cat-cafe:agents    providers/claude.js  providers/codex.js
                           ↕                    ↕
-                    Anthropic API          codex.exe (本地)
-                    /v1/messages
+                    Claude Code CLI        codex.exe (本地)
+                    (本地子进程)
 ```
 
 - 前端唯一状态源：`useChatStore` + `useAgentStore`（无 Zustand/Redux）
@@ -80,13 +80,14 @@ cp .env.example .env
 编辑 `.env`：
 
 ```env
-# Bridge 侧 Claude API Key（只在 bridge/server.js 中读取，不进前端 bundle）
-CLAUDE_API_KEY=sk-ant-xxxxxxxx
-
 VITE_CODEX_BRIDGE_URL=http://localhost:4891
 
 # 可选：指定 codex.exe 路径
 # CODEX_EXE_PATH=C:\path\to\codex.exe
+
+# 可选：内置 Claude agent 默认使用本地 Claude Code CLI 登录态（claude login）
+# 如需为自定义 Claude-compatible agent 指定默认 API Key，可在此设置
+# CLAUDE_API_KEY=sk-ant-xxxxxxxx
 ```
 
 ### 启动
@@ -103,10 +104,10 @@ npm run dev
 
 | Agent | 模型 | Provider |
 |-------|------|----------|
-| 布偶猫 | claude-sonnet-4-6 | Anthropic API |
+| 布偶猫 | claude-sonnet-4-6 | Claude Code CLI（本地） |
 | 缅因猫 | gpt-5.4 | Codex CLI（本地） |
 
-在右侧边栏可添加、编辑、删除 Agent，配置项包括：模型 ID、System Prompt。Claude-compatible provider 额外支持 Base URL（可选）和 API Key（可选），API Key 仅存 bridge Redis，不回传前端，留空则使用 bridge `.env` 中的默认 Key；Codex provider 通过本地 CLI 调用，不支持自定义凭据。
+在右侧边栏可添加、编辑、删除 Agent，配置项包括：模型 ID、System Prompt。Claude-compatible provider 额外支持 Base URL（可选）和 API Key（可选），API Key 仅存 bridge Redis，不回传前端，留空则使用本地 Claude Code CLI 登录态；Codex provider 通过本地 CLI 调用，不支持自定义凭据。
 
 ---
 
@@ -140,7 +141,7 @@ bridge/
   gateway.js             # Provider 路由，SSE 输出
   policy.js              # 超时 / 重试 / 限流 / 日志
   providers/
-    claude.js            # Anthropic API 适配器
+    claude.js            # Claude Code CLI 适配器（本地子进程）
     codex.js             # Codex CLI 适配器
 ```
 
@@ -151,7 +152,7 @@ bridge/
 - 前端：Vite + React 18 + Tailwind CSS + marked + DOMPurify
 - Bridge：Node.js + Express + ioredis
 - 存储：Redis（会话 + Agent 配置）
-- AI：Anthropic API（SSE）/ OpenAI Codex CLI（子进程 + JSON 流）
+- AI：Claude Code CLI（本地子进程 + JSON 流）/ OpenAI Codex CLI（子进程 + JSON 流）
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -74,26 +74,29 @@ cd bridge && npm install && cd ..
 
 ### 配置
 
+`.env` 仅供 Vite 前端读取（`VITE_*` 变量）。bridge 侧变量需通过 shell 环境变量传入（`export` 或在启动命令前设置）。
+
 ```bash
 cp .env.example .env
 ```
 
-编辑 `.env`：
+`.env`（Vite 前端变量）：
 
 ```env
 VITE_CODEX_BRIDGE_URL=http://localhost:4891
-
-# 可选：指定 claude CLI 路径（默认使用 PATH 中的 claude）
-# CLAUDE_EXE_PATH=C:\path\to\claude.exe
-
-# 可选：指定 codex.exe 路径
-# CODEX_EXE_PATH=C:\path\to\codex.exe
-
-# 旧路由 /claude/stream 专用（已废弃，仅向后兼容保留）
-# 内置 Claude agent 及自定义 Claude-compatible agent 均不读取此变量
-# 自定义 agent 的 apiKey 在 UI 中单独配置，存 Redis，不进 .env
-# CLAUDE_API_KEY=sk-ant-xxxxxxxx
 ```
+
+bridge 侧 shell 环境变量（可选）：
+
+```bash
+# Claude CLI 路径（默认使用 PATH 中的 claude）
+export CLAUDE_EXE_PATH=C:\path\to\claude.exe
+
+# Codex CLI 路径
+export CODEX_EXE_PATH=C:\path\to\codex.exe
+```
+
+内置 Claude agent 默认使用本地 `claude login` 登录态，无需额外配置。自定义 agent 的 apiKey 在 UI 中单独配置，存 Redis，不经过环境变量。
 
 ### 启动
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,15 @@ cp .env.example .env
 ```env
 VITE_CODEX_BRIDGE_URL=http://localhost:4891
 
+# 可选：指定 claude CLI 路径（默认使用 PATH 中的 claude）
+# CLAUDE_EXE_PATH=C:\path\to\claude.exe
+
 # 可选：指定 codex.exe 路径
 # CODEX_EXE_PATH=C:\path\to\codex.exe
 
-# 可选：内置 Claude agent 默认使用本地 Claude Code CLI 登录态（claude login）
-# 如需为自定义 Claude-compatible agent 指定默认 API Key，可在此设置
+# 旧路由 /claude/stream 专用（已废弃，仅向后兼容保留）
+# 内置 Claude agent 及自定义 Claude-compatible agent 均不读取此变量
+# 自定义 agent 的 apiKey 在 UI 中单独配置，存 Redis，不进 .env
 # CLAUDE_API_KEY=sk-ant-xxxxxxxx
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ bridge/server.js  (Express :4891)
 |------|------|
 | Node.js 18+ | 前端 + bridge |
 | Redis | WSL 内运行：`wsl redis-server --daemonize yes`，监听 `127.0.0.1:6379` |
+| Claude Code CLI | 内置 Claude agent 必需；安装后执行 `claude login`；或通过 `CLAUDE_EXE_PATH` 指定路径 |
 | codex.exe | 可选，OpenAI Codex CLI，路径由 `CODEX_EXE_PATH` 环境变量指定 |
 
 ### 安装


### PR DESCRIPTION
## What changed

`CLAUDE.md` 和 `README.md` 同步至 PR #34/#38 合并后的实际架构。

### CLAUDE.md
- 架构图：Claude provider 指向 `Claude Code CLI（本地子进程）`
- 环境依赖表：新增 `Claude Code CLI` 依赖，`CLAUDE_API_KEY` 改为可选说明
- 已知问题表：补充 #33、#36 已修复，标题从"P1 问题"改为"问题状态"
- 演进路径：Claude CLI backend 移入已完成，新增 #37 smoke test 待完成项

### README.md
- 一句话定位：说明内置 Claude agent 走本地 CLI
- 架构图：`Anthropic API /v1/messages` 改为 `Claude Code CLI（本地子进程）`
- 内置 Agent 表：布偶猫 Provider 从 `Anthropic API` 改为 `Claude Code CLI（本地）`
- 配置说明：`CLAUDE_API_KEY` 改为可选注释，默认走本地登录态
- 自定义 Agent 说明：留空 apiKey 时说明使用本地 CLI 登录态
- 目录结构：`claude.js` 注释从 `Anthropic API 适配器` 改为 `Claude Code CLI 适配器（本地子进程）`
- 技术栈：`Anthropic API（SSE）` 改为 `Claude Code CLI（本地子进程 + JSON 流）`

## Why

issue #35：PR #34 合并后文档仍描述旧的 API-backed 架构，造成 onboarding 和 review 混淆。

## What was NOT changed

代码、配置、Redis schema 均未改动，纯文档更新。

## Docs impact

`README.md`、`CLAUDE.md`

## Linked issue

Closes #35
