### PR TITLE
docs(agents): harden AGENTS.md for docs-impact, smoke validation, review conclusions, close-out flow (close #39)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,21 @@ Every PR must contain:
 - Risks
 - Validation steps
 - Linked issue(s)
+- **Docs impact** (required): one of:
+  - `Docs impact: none`
+  - `Docs impact: README.md`
+  - `Docs impact: CLAUDE.md`
+  - `Docs impact: AGENTS.md`
+  - `Docs impact: follow-up issue #<id>` (with explicit rationale for deferral)
+
+If a PR changes any of the following, docs must be reviewed explicitly before merge:
+- architecture shape
+- runtime backend
+- auth model
+- setup / onboarding path
+- built-in provider behavior
+
+If docs/tests are intentionally deferred, the PR must link a specific follow-up issue and state why deferral is acceptable.
 
 Preferred PR size:
 - keep focused
@@ -251,6 +266,15 @@ Minimum expectation:
 - run lint / typecheck if configured
 - include exact validation commands in the PR description
 
+**Built-in agent smoke validation (required for provider/runtime changes):**
+
+When a PR touches any of: provider adapter, bridge runtime, streaming logic, auth model, CLI wiring — the validation bar must include a local smoke check for built-in agents before requesting review:
+
+- built-in Claude agent: send a simple `hello` request, verify a non-empty response is returned
+- built-in Codex agent: send a simple `hello` request, verify a non-empty response is returned
+
+Include the smoke check result (pass/fail + observed output) in the PR validation section.
+
 For async stream / generator subsystems, explicitly trace all exit paths before patching:
 - normal completion
 - timeout
@@ -306,5 +330,39 @@ A PR is ready to merge only if:
 - risks are documented
 - no unresolved scope ambiguity remains
 - for stream/async subsystems: all exit paths (normal, timeout, yielded error, thrown error, client abort) have been explicitly verified
+- **docs impact field is present and addressed** — if docs were deferred, a follow-up issue must be linked
+- **for provider/runtime/auth/setup changes: built-in agent smoke check passed** and result is documented in PR
 
 Correct and small beats clever and sprawling.
+
+---
+
+## 15. Review conclusion protocol
+
+Reviewer findings must be posted as PR review comments or inline comments on GitHub — not only summarized in chat.
+
+After completing a review pass:
+- if blocking findings remain: publish an explicit **Request changes** review on the PR
+- if no blocking findings remain: publish an explicit **Approve** review on the PR
+- resolving threads alone does not replace a final review conclusion
+
+After re-review:
+- reviewer must update the PR with the current verdict (approve or request changes)
+- do not leave the final state implicit
+
+---
+
+## 16. Collaborator close-out flow
+
+When the reviewer is also acting as collaborator and a PR is approved and mergeable:
+
+1. Review findings are posted to the PR
+2. Author addresses feedback and requests re-review
+3. Reviewer re-checks and publishes the final review conclusion on the PR
+4. Collaborator performs close-out:
+   - approve the PR on GitHub
+   - merge using the repository's normal merge style
+   - verify linked issue closure behavior (auto-close via `Closes #N` in PR body)
+   - manually close linked issues if auto-close does not trigger
+   - sync local `master`: `git checkout master && git pull origin master`
+   - clean up temporary branches: delete remote fix branch after merge, delete local branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,7 @@ When debugging intertwined failure modes in one subsystem:
 ## 12. Forbidden behavior
 
 Do not:
-- commit directly to `main`
+- commit directly to `master`
 - rewrite unrelated files
 - silently rename core concepts
 - change public interfaces without documenting it
@@ -331,7 +331,7 @@ A PR is ready to merge only if:
 - no unresolved scope ambiguity remains
 - for stream/async subsystems: all exit paths (normal, timeout, yielded error, thrown error, client abort) have been explicitly verified
 - **docs impact field is present and addressed** — if docs were deferred, a follow-up issue must be linked
-- **for provider/runtime/auth/setup changes: built-in agent smoke check passed** and result is documented in PR
+- **for provider/runtime/auth/setup/streaming/CLI changes: built-in agent smoke check passed** and result is documented in PR
 
 Correct and small beats clever and sprawling.
 
@@ -354,7 +354,7 @@ After re-review:
 
 ## 16. Collaborator close-out flow
 
-When the reviewer is also acting as collaborator and a PR is approved and mergeable:
+This flow applies only when the human maintainer has explicitly delegated close-out authority (e.g. "go ahead and merge"). Section 3 remains the default: the human maintainer is the final decision-maker for merge. When delegated, the expected flow is:
 
 1. Review findings are posted to the PR
 2. Author addresses feedback and requests re-review


### PR DESCRIPTION
## What changed

`AGENTS.md` hardened with 6 new process rules per issue #39.

### §6 Pull request protocol
- Added required `Docs impact` field to every PR (none / README.md / CLAUDE.md / AGENTS.md / follow-up issue #N)
- Added explicit list of contract changes that require docs review before merge (architecture, runtime backend, auth model, setup/onboarding, built-in provider behavior)
- Added rule: if docs/tests are intentionally deferred, PR must link a specific follow-up issue with rationale

### §11 Testing rules
- Added built-in agent smoke validation requirement for provider/runtime/auth/CLI changes
- Minimum bar: built-in Claude agent and Codex agent each return non-empty response to a `hello` request
- Smoke check result must be included in PR validation section

### §14 Definition of done
- Added: docs impact field must be present and addressed (or follow-up issue linked)
- Added: for provider/runtime/auth/setup changes, built-in agent smoke check must pass and be documented

### §15 Review conclusion protocol (new section)
- Findings must be posted as PR review comments, not only in chat
- Blocking findings → explicit Request changes on PR
- No blocking findings → explicit Approve on PR
- Resolving threads alone does not replace a final review conclusion
- After re-review, reviewer must publish updated verdict

### §16 Collaborator close-out flow (new section)
- Documents the expected end-of-PR flow: review → address → re-review → approve → merge → verify issue closure → sync master → clean branches

## Why

issue #39: recent PRs exposed process gaps — docs drifted after Claude CLI migration, PR #34 shipped broken built-in Claude runtime without smoke validation, review conclusions were inferred from thread state rather than published explicitly.

## What was NOT changed

No code changes. No existing AGENTS.md sections removed or reworded beyond the targeted additions.

## Risks

Low. Pure process documentation. No runtime impact.

## Validation

Diff review only — no code to test.

## Docs impact

`Docs impact: AGENTS.md`

## Linked issue

Closes #39