### PR TITLE
test: add built-in agent e2e smoke tests (close #37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@
 | #23 | @mention token 泄漏进 provider prompt | ✅ 已修复（stripMentions） |
 | #33 | claude provider 实现与本地 agent 架构不符 | ✅ 已修复（CLI 后端替换） |
 | #36 | Claude CLI provider stdin 未关闭导致所有请求 timeout | ✅ 已修复（child.stdin.end()） |
+| #37 | 内置 agent e2e smoke test | ✅ 已修复（node:test + gateway SSE 验证） |
 | #16 | @mention 链式调用无循环保护 | 🔴 待修复 |
 
 ## 演进路径
@@ -67,10 +68,10 @@
   bridge 不可用错误提示 + 重试 ✓
   @mention token 不泄漏进 provider prompt ✓
   Claude provider 替换为本地 Claude Code CLI 后端 ✓
+  内置 agent e2e smoke test ✓
 
 下一步
   @mention 链式调用循环保护（issue #16）
-  内置 agent e2e smoke test（issue #37）
   Agent 工作目录隔离（每会话独立 cwd）
   消息导出（Markdown/JSON）
 

--- a/bridge/server.js
+++ b/bridge/server.js
@@ -252,7 +252,7 @@ app.post('/codex/stream', requireLocalToken, (req, res) => {
 registerGateway(app, requireLocalToken, redis, AGENTS_KEY)
 
 // 同时绑定 IPv4 和 IPv6 loopback，避免 localhost 在 IPv6-first 环境解析到 ::1 时连接失败
-const PORT = Number(process.env.PORT) || 4891
+const PORT = Number(process.env.BRIDGE_PORT) || 4891
 app.listen(PORT, '127.0.0.1', () => {
   console.log(`[bridge] listening on http://127.0.0.1:${PORT}`)
 })

--- a/bridge/server.js
+++ b/bridge/server.js
@@ -252,7 +252,7 @@ app.post('/codex/stream', requireLocalToken, (req, res) => {
 registerGateway(app, requireLocalToken, redis, AGENTS_KEY)
 
 // 同时绑定 IPv4 和 IPv6 loopback，避免 localhost 在 IPv6-first 环境解析到 ::1 时连接失败
-const PORT = 4891
+const PORT = Number(process.env.PORT) || 4891
 app.listen(PORT, '127.0.0.1', () => {
   console.log(`[bridge] listening on http://127.0.0.1:${PORT}`)
 })

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "concurrently --kill-others-on-fail -n bridge,vite -c cyan,green \"node bridge/server.js\" \"vite\"",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:smoke": "node --test tests/smoke.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -68,9 +68,17 @@ export function startBridge() {
  * @param {number} timeoutMs
  * @returns {Promise<{ chunks: string[], events: object[] }>}
  */
-export async function streamGateway(bridge, { provider, message }, timeoutMs = 65_000) {
+export async function streamGateway(bridge, { provider, message, model, systemPrompt, agentId }, timeoutMs = 65_000) {
   const ac = new AbortController()
   const timer = setTimeout(() => ac.abort(), timeoutMs)
+
+  const body = {
+    provider,
+    messages: [{ role: 'user', content: message }],
+  }
+  if (model) body.model = model
+  if (systemPrompt) body.systemPrompt = systemPrompt
+  if (agentId) body.agentId = agentId
 
   const res = await fetch(`${bridge.baseUrl}/gateway/stream`, {
     method: 'POST',
@@ -78,10 +86,7 @@ export async function streamGateway(bridge, { provider, message }, timeoutMs = 6
       'Content-Type': 'application/json',
       'x-local-token': bridge.token,
     },
-    body: JSON.stringify({
-      provider,
-      messages: [{ role: 'user', content: message }],
-    }),
+    body: JSON.stringify(body),
     signal: ac.signal,
   })
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,127 @@
+/**
+ * Smoke test helpers
+ * - startBridge(): spawn bridge/server.js, wait for ready, return { baseUrl, token, kill }
+ * - streamGateway(): POST /gateway/stream, parse SSE, return collected events
+ */
+import { spawn } from 'child_process'
+
+const BRIDGE_PORT = 14891 // 用非默认端口避免与开发环境冲突
+const BRIDGE_URL = `http://127.0.0.1:${BRIDGE_PORT}`
+const STARTUP_TIMEOUT = 10_000
+
+/**
+ * 启动 bridge 子进程，等待 ready 输出
+ * @returns {{ baseUrl: string, token: string, kill: () => void }}
+ */
+export function startBridge() {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', ['bridge/server.js'], {
+      env: { ...process.env, PORT: String(BRIDGE_PORT) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    const timer = setTimeout(() => {
+      child.kill()
+      reject(new Error(`Bridge did not start within ${STARTUP_TIMEOUT}ms.\nstdout: ${stdout}`))
+    }, STARTUP_TIMEOUT)
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString()
+      if (stdout.includes('listening on')) {
+        clearTimeout(timer)
+        // 获取 token
+        fetch(`${BRIDGE_URL}/token`)
+          .then(r => r.json())
+          .then(({ token }) => resolve({
+            baseUrl: BRIDGE_URL,
+            token,
+            kill: () => child.kill(),
+          }))
+          .catch(reject)
+      }
+    })
+
+    child.stderr.on('data', (chunk) => {
+      // stderr 输出到 console 方便调试
+      process.stderr.write(`[bridge] ${chunk}`)
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      if (code !== null && code !== 0) {
+        reject(new Error(`Bridge exited with code ${code}.\nstdout: ${stdout}`))
+      }
+    })
+  })
+}
+
+/**
+ * POST /gateway/stream，收集 SSE 事件直到 done/error 或超时
+ * @param {{ baseUrl: string, token: string }} bridge
+ * @param {{ provider: string, message: string }} opts
+ * @param {number} timeoutMs
+ * @returns {Promise<{ chunks: string[], events: object[] }>}
+ */
+export async function streamGateway(bridge, { provider, message }, timeoutMs = 30_000) {
+  const ac = new AbortController()
+  const timer = setTimeout(() => ac.abort(), timeoutMs)
+
+  const res = await fetch(`${bridge.baseUrl}/gateway/stream`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-local-token': bridge.token,
+    },
+    body: JSON.stringify({
+      provider,
+      messages: [{ role: 'user', content: message }],
+    }),
+    signal: ac.signal,
+  })
+
+  if (!res.ok) {
+    clearTimeout(timer)
+    const body = await res.text()
+    throw new Error(`Gateway returned ${res.status}: ${body}`)
+  }
+
+  const chunks = []
+  const events = []
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      const lines = buf.split('\n')
+      buf = lines.pop()
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue
+        const payload = line.slice(6).trim()
+        if (!payload) continue
+        try {
+          const event = JSON.parse(payload)
+          events.push(event)
+          if (event.type === 'chunk' && event.text) chunks.push(event.text)
+          if (event.type === 'done' || event.type === 'error') {
+            clearTimeout(timer)
+            return { chunks, events }
+          }
+        } catch { /* 忽略非 JSON */ }
+      }
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+
+  return { chunks, events }
+}

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -16,7 +16,7 @@ const STARTUP_TIMEOUT = 10_000
 export function startBridge() {
   return new Promise((resolve, reject) => {
     const child = spawn('node', ['bridge/server.js'], {
-      env: { ...process.env, PORT: String(BRIDGE_PORT) },
+      env: { ...process.env, BRIDGE_PORT: String(BRIDGE_PORT) },
       stdio: ['ignore', 'pipe', 'pipe'],
     })
 
@@ -68,7 +68,7 @@ export function startBridge() {
  * @param {number} timeoutMs
  * @returns {Promise<{ chunks: string[], events: object[] }>}
  */
-export async function streamGateway(bridge, { provider, message }, timeoutMs = 30_000) {
+export async function streamGateway(bridge, { provider, message }, timeoutMs = 65_000) {
   const ac = new AbortController()
   const timer = setTimeout(() => ac.abort(), timeoutMs)
 

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -1,0 +1,45 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { startBridge, streamGateway } from './helpers.js'
+
+describe('built-in agent smoke test', () => {
+  let bridge
+
+  before(async () => {
+    bridge = await startBridge()
+  })
+
+  after(() => {
+    bridge?.kill()
+  })
+
+  it('Claude agent (claudecode) returns non-empty response to hello', async () => {
+    const { chunks, events } = await streamGateway(bridge, {
+      provider: 'claudecode',
+      message: 'hello',
+    })
+
+    const doneEvent = events.find(e => e.type === 'done')
+    const errorEvent = events.find(e => e.type === 'error')
+
+    assert.ok(!errorEvent, `Expected no error, got: ${errorEvent?.message}`)
+    assert.ok(doneEvent, 'Expected a done event')
+    assert.ok(chunks.length > 0, 'Expected at least one text chunk')
+    assert.ok(chunks.join('').trim().length > 0, 'Expected non-empty response text')
+  })
+
+  it('Codex agent (codex) returns non-empty response to hello', async () => {
+    const { chunks, events } = await streamGateway(bridge, {
+      provider: 'codex',
+      message: 'hello',
+    })
+
+    const doneEvent = events.find(e => e.type === 'done')
+    const errorEvent = events.find(e => e.type === 'error')
+
+    assert.ok(!errorEvent, `Expected no error, got: ${errorEvent?.message}`)
+    assert.ok(doneEvent, 'Expected a done event')
+    assert.ok(chunks.length > 0, 'Expected at least one text chunk')
+    assert.ok(chunks.join('').trim().length > 0, 'Expected non-empty response text')
+  })
+})

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -17,6 +17,8 @@ describe('built-in agent smoke test', () => {
     const { chunks, events } = await streamGateway(bridge, {
       provider: 'claudecode',
       message: 'hello',
+      model: 'claude-sonnet-4-6',
+      agentId: 'claude',
     })
 
     const doneEvent = events.find(e => e.type === 'done')
@@ -32,6 +34,8 @@ describe('built-in agent smoke test', () => {
     const { chunks, events } = await streamGateway(bridge, {
       provider: 'codex',
       message: 'hello',
+      model: 'gpt-5.4',
+      agentId: 'codex',
     })
 
     const errorEvent = events.find(e => e.type === 'error')

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -28,14 +28,21 @@ describe('built-in agent smoke test', () => {
     assert.ok(chunks.join('').trim().length > 0, 'Expected non-empty response text')
   })
 
-  it('Codex agent (codex) returns non-empty response to hello', async () => {
+  it('Codex agent (codex) returns non-empty response to hello', async (t) => {
     const { chunks, events } = await streamGateway(bridge, {
       provider: 'codex',
       message: 'hello',
     })
 
-    const doneEvent = events.find(e => e.type === 'done')
     const errorEvent = events.find(e => e.type === 'error')
+
+    // codex.exe 是可选依赖，不可用时跳过而非失败
+    if (errorEvent?.message?.includes('not found')) {
+      t.skip('codex.exe not available')
+      return
+    }
+
+    const doneEvent = events.find(e => e.type === 'done')
 
     assert.ok(!errorEvent, `Expected no error, got: ${errorEvent?.message}`)
     assert.ok(doneEvent, 'Expected a done event')

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -31,6 +31,12 @@ describe('built-in agent smoke test', () => {
   })
 
   it('Codex agent (codex) returns non-empty response to hello', async (t) => {
+    // 显式跳过：仅当 SMOKE_SKIP_CODEX=1 时允许跳过，避免 suite 静默降级
+    if (process.env.SMOKE_SKIP_CODEX === '1') {
+      t.skip('SMOKE_SKIP_CODEX=1: explicitly skipped by user')
+      return
+    }
+
     const { chunks, events } = await streamGateway(bridge, {
       provider: 'codex',
       message: 'hello',
@@ -40,10 +46,12 @@ describe('built-in agent smoke test', () => {
 
     const errorEvent = events.find(e => e.type === 'error')
 
-    // codex.exe 是可选依赖，不可用时跳过而非失败
+    // codex.exe 不可用时 fail 并给出清晰的前置条件提示
     if (errorEvent?.message?.includes('not found')) {
-      t.skip('codex.exe not available')
-      return
+      assert.fail(
+        'Codex CLI not available. Install codex and set CODEX_EXE_PATH, ' +
+        'or set SMOKE_SKIP_CODEX=1 to explicitly skip this case.'
+      )
     }
 
     const doneEvent = events.find(e => e.type === 'done')


### PR DESCRIPTION
## What changed

添加本地 e2e smoke test，验证两个内置 agent（Claude + Codex）能通过 gateway 正常响应 `hello` 请求。

### 变更内容

1. `bridge/server.js` — PORT 改为可配置（`process.env.PORT || 4891`），测试用 14891 避免冲突
2. `package.json` — 新增 `test:smoke` script
3. `tests/helpers.js` — bridge 生命周期管理（startBridge/kill）+ SSE 事件解析（streamGateway）
4. `tests/smoke.test.js` — 两个 test case：Claude agent 和 Codex agent 各发一次 `hello`，断言非空响应 + done 事件
5. `CLAUDE.md` — issue 状态表和演进路径更新

### 技术选型

- `node:test` + `node:assert` + native `fetch`（Node 18+ 内置，零新依赖）
- 直接 HTTP 请求 bridge `/gateway/stream`，不需要 Playwright/浏览器
- 测试用独立端口 14891，不干扰开发环境

## Why

issue #37：PR #34 合并后内置 Claude agent 运行时仍然失败，因为没有 smoke test 覆盖 bridge→provider→CLI 管线。

## What was NOT changed

- 前端代码未改动
- Provider adapter 逻辑未改动
- Redis schema 未改动

## Risks

Low.新增测试文件 + bridge PORT 可配置（默认值不变）。

## Validation

本地前置条件：
- Redis 运行中（`127.0.0.1:6379`）
- Claude Code CLI 可用（`claude login` 已完成）
- Codex CLI 可用（`CODEX_EXE_PATH` 已设置）

运行命令：
```bash
npm run test:smoke
```

## Docs impact

`Docs impact: CLAUDE.md`（issue 状态表 + 演进路径已更新）

## Linked issue

Closes #37