### PR TITLE
fix(streaming): remove gateway wall-clock timeout and require explicit done semantics

### DIFF
--- a/bridge/policy.js
+++ b/bridge/policy.js
@@ -1,7 +1,6 @@
 /**
  * Gateway Policy Layer
  * 为所有 provider adapter 提供统一的：
- * - 请求超时
  * - retry / backoff（仅幂等场景）
  * - 并发限流
  * - 结构化日志
@@ -11,7 +10,6 @@
 // ── 配置 ──────────────────────────────────────────────────────────────────────
 
 const POLICY = {
-  timeoutMs: Number(process.env.GATEWAY_TIMEOUT_MS) || 60_000,
   maxRetries: Number(process.env.GATEWAY_MAX_RETRIES) || 2,
   retryBaseMs: Number(process.env.GATEWAY_RETRY_BASE_MS) || 500,
   maxConcurrency: Number(process.env.GATEWAY_MAX_CONCURRENCY) || 10,
@@ -49,17 +47,6 @@ function isRetryable(err) {
 // ── sleep ─────────────────────────────────────────────────────────────────────
 
 const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
-
-// ── 合并多个 AbortSignal ──────────────────────────────────────────────────────
-
-function anyAbort(...signals) {
-  const ac = new AbortController()
-  for (const s of signals) {
-    if (s.aborted) { ac.abort(); break }
-    s.addEventListener('abort', () => ac.abort(), { once: true })
-  }
-  return ac.signal
-}
 
 // ── 核心：withPolicy ──────────────────────────────────────────────────────────
 
@@ -99,19 +86,13 @@ export async function* withPolicy(provider, streamFn, params) {
         return
       }
 
-      const timeoutAc = new AbortController()
-      const timer = setTimeout(() => timeoutAc.abort(), POLICY.timeoutMs)
-      const signal = params.signal
-        ? anyAbort(params.signal, timeoutAc.signal)
-        : timeoutAc.signal
-
       let usage = null
       let chunks = 0
       let yieldedError = null  // adapter 以 event 形式 yield 的错误
-      let timedOut = false
+      let sawDone = false
 
       try {
-        for await (const event of streamFn({ ...params, signal })) {
+        for await (const event of streamFn(params)) {
           if (event.type === 'chunk') chunks++
           if (event.type === 'usage') usage = event.usage
 
@@ -122,28 +103,16 @@ export async function* withPolicy(provider, streamFn, params) {
           }
 
           yield event
-          if (event.type === 'done') break
+          if (event.type === 'done') {
+            sawDone = true
+            break
+          }
         }
-      } finally {
-        clearTimeout(timer)
-        // 超时：timeoutAc 已 abort 但客户端未 abort
-        if (timeoutAc.signal.aborted && !params.signal?.aborted) {
-          timedOut = true
-        }
-      }
+      } finally {}
 
       // 客户端主动断开
       if (params.signal?.aborted) {
         log('info', provider, 'request aborted by client', { durationMs: Date.now() - startTs })
-        return
-      }
-
-      // 超时
-      if (timedOut) {
-        log('warn', provider, 'request timeout', { timeoutMs: POLICY.timeoutMs, attempt })
-        lastErr = Object.assign(new Error(`Request timed out after ${POLICY.timeoutMs}ms`), { _timeout: true })
-        // 超时不重试（流式请求不幂等）
-        yield { type: 'error', message: lastErr.message }
         return
       }
 
@@ -155,6 +124,13 @@ export async function* withPolicy(provider, streamFn, params) {
           attempt++
           continue
         }
+        log('error', provider, 'request failed', { error: lastErr.message, attempts: attempt + 1, chunks })
+        yield { type: 'error', message: lastErr.message }
+        return
+      }
+
+      if (!sawDone) {
+        lastErr = new Error('Stream terminated without explicit done event')
         log('error', provider, 'request failed', { error: lastErr.message, attempts: attempt + 1, chunks })
         yield { type: 'error', message: lastErr.message }
         return

--- a/bridge/policy.js
+++ b/bridge/policy.js
@@ -92,7 +92,7 @@ export async function* withPolicy(provider, streamFn, params) {
       let sawDone = false
 
       try {
-        for await (const event of streamFn(params)) {
+        for await (const event of streamFn({ ...params, signal: params.signal })) {
           if (event.type === 'chunk') chunks++
           if (event.type === 'usage') usage = event.usage
 

--- a/bridge/providers/codex.js
+++ b/bridge/providers/codex.js
@@ -80,8 +80,14 @@ export async function* stream({ messages, model, signal }) {
     emitter.emit('data')
   })
 
-  child.on('close', () => {
-    if (!signal?.aborted) push({ type: 'done' })
+  child.on('close', (code) => {
+    if (!signal?.aborted) {
+      if (code === 0) {
+        push({ type: 'done' })
+      } else {
+        push({ type: 'error', message: `codex CLI exited with code ${code}` })
+      }
+    }
     closed = true
     emitter.emit('data')
   })

--- a/docs/plans/2026-03-20-issue-45-streaming-timeout-semantics.md
+++ b/docs/plans/2026-03-20-issue-45-streaming-timeout-semantics.md
@@ -1,0 +1,177 @@
+# Issue 45 Streaming Timeout Semantics Implementation Plan
+
+> **For AI:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove gateway-level wall-clock stream timeout semantics and make successful completion depend on explicit provider `done` signals instead of implicit stream closure.
+
+**Architecture:** The fix stays within the existing gateway/provider/frontend pipeline. The gateway policy layer stops defining business-level stream failure based on total elapsed time, provider adapters become responsible for explicit success/error terminal events, and the frontend only treats a request as successful when it sees an explicit `done` event. Tests cover all affected exit paths so timeout removal does not silently weaken abnormal-exit detection.
+
+**Tech Stack:** Node.js, Express SSE, async generators, React frontend fetch streaming, node:test
+
+---
+
+### Task 1: Lock The Current Failure Modes With Tests
+
+**Files:**
+- Modify: `D:\Develop\Project\claudecode\newtry\opencats\tests\auth.test.js` (do not touch)
+- Create: `D:\Develop\Project\claudecode\newtry\opencats\tests\policy.test.js`
+- Create: `D:\Develop\Project\claudecode\newtry\opencats\tests\gatewayAgent.test.js`
+- Create: `D:\Develop\Project\claudecode\newtry\opencats\tests\codex-provider.test.js`
+
+**Step 1: Write the failing policy test**
+
+```js
+it('does not emit timeout error solely because elapsed wall-clock time exceeds the old gateway limit', async () => {
+  process.env.GATEWAY_TIMEOUT_MS = '50'
+  const events = []
+  for await (const event of withPolicy('demo', providerAwareSlowStream, { model: 'm' })) {
+    events.push(event)
+  }
+  assert.deepEqual(events, [{ type: 'chunk', text: 'partial' }])
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test tests/policy.test.js`
+Expected: FAIL because current implementation appends `Request timed out after 50ms`
+
+**Step 3: Write the failing codex abnormal-exit test**
+
+```js
+it('yields error instead of done when codex process exits non-zero', async () => {
+  // stub child_process.spawn and feed a close(1) without turn.completed success marker
+})
+```
+
+**Step 4: Run test to verify it fails**
+
+Run: `node --test tests/codex-provider.test.js`
+Expected: FAIL because current provider emits `done` on any close
+
+**Step 5: Write the failing frontend completion test**
+
+```js
+it('does not call onDone when the SSE stream closes without an explicit done event', async () => {
+  // stub fetch to return one chunk and then EOF
+})
+```
+
+**Step 6: Run test to verify it fails**
+
+Run: `node --test tests/gatewayAgent.test.js`
+Expected: FAIL because current implementation calls `onDone` after EOF
+
+### Task 2: Remove Gateway-Level Business Timeout Semantics
+
+**Files:**
+- Modify: `D:\Develop\Project\claudecode\newtry\opencats\bridge\policy.js`
+- Test: `D:\Develop\Project\claudecode\newtry\opencats\tests\policy.test.js`
+
+**Step 1: Implement minimal policy change**
+
+```js
+// remove timeoutAc/timedOut branch from withPolicy
+// keep client abort handling, concurrency limiting, and retry-on-yielded-error-before-chunks
+```
+
+**Step 2: Run focused test**
+
+Run: `node --test tests/policy.test.js`
+Expected: PASS
+
+**Step 3: Run broader affected tests**
+
+Run: `node --test tests/policy.test.js tests/codex-provider.test.js`
+Expected: existing provider semantics tests still show the remaining failing codex case only
+
+### Task 3: Tighten Provider Terminal Semantics
+
+**Files:**
+- Modify: `D:\Develop\Project\claudecode\newtry\opencats\bridge\providers\codex.js`
+- Optionally inspect only: `D:\Develop\Project\claudecode\newtry\opencats\bridge\providers\claude.js`
+- Test: `D:\Develop\Project\claudecode\newtry\opencats\tests\codex-provider.test.js`
+
+**Step 1: Write minimal codex fix**
+
+```js
+child.on('close', (code) => {
+  if (!signal?.aborted) {
+    if (code === 0) push({ type: 'done' })
+    else push({ type: 'error', message: `codex exited with code ${code}` })
+  }
+  closed = true
+  emitter.emit('data')
+})
+```
+
+**Step 2: Run provider test**
+
+Run: `node --test tests/codex-provider.test.js`
+Expected: PASS
+
+**Step 3: Run regression test on existing auth-related suite only if touched indirectly**
+
+Run: `node --test tests/codex-provider.test.js tests/policy.test.js`
+Expected: PASS
+
+### Task 4: Require Explicit `done` On The Frontend
+
+**Files:**
+- Modify: `D:\Develop\Project\claudecode\newtry\opencats\src\agents\gatewayAgent.js`
+- Test: `D:\Develop\Project\claudecode\newtry\opencats\tests\gatewayAgent.test.js`
+
+**Step 1: Implement minimal frontend fix**
+
+```js
+let sawDone = false
+// ...
+if (json.type === 'done') {
+  sawDone = true
+  stopReading = true
+}
+// ...
+if (!sawDone) throw new Error('Stream terminated without explicit done event')
+onDone?.(fullText, usage)
+```
+
+**Step 2: Run frontend test**
+
+Run: `node --test tests/gatewayAgent.test.js`
+Expected: PASS
+
+**Step 3: Re-run combined stream semantics tests**
+
+Run: `node --test tests/policy.test.js tests/codex-provider.test.js tests/gatewayAgent.test.js`
+Expected: PASS
+
+### Task 5: Verify End-To-End Impact And Update Validation Surface
+
+**Files:**
+- Modify: `D:\Develop\Project\claudecode\newtry\opencats\package.json`
+- Optionally create/update: `D:\Develop\Project\claudecode\newtry\opencats\tests\stream-semantics.test.js`
+- Inspect only: `D:\Develop\Project\claudecode\newtry\opencats\tests\smoke.test.js`
+
+**Step 1: Add targeted test script only if it materially improves workflow**
+
+```json
+"test:stream": "node --test tests/policy.test.js tests/codex-provider.test.js tests/gatewayAgent.test.js"
+```
+
+**Step 2: Run final verification**
+
+Run: `npm run build`
+Expected: PASS
+
+Run: `node --test tests/policy.test.js tests/codex-provider.test.js tests/gatewayAgent.test.js`
+Expected: PASS
+
+Run: `npm run test:smoke`
+Expected: PASS if local CLIs are available; otherwise document exact blocker and observed output
+
+**Step 3: Commit**
+
+```bash
+git add bridge/policy.js bridge/providers/codex.js src/agents/gatewayAgent.js tests/policy.test.js tests/codex-provider.test.js tests/gatewayAgent.test.js package.json docs/plans/2026-03-20-issue-45-streaming-timeout-semantics.md
+git commit -m "fix: tighten streaming completion semantics"
+```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "concurrently --kill-others-on-fail -n bridge,vite -c cyan,green \"node bridge/server.js\" \"vite\"",
     "build": "vite build",
     "preview": "vite preview",
+    "test:stream": "node --test tests/policy.test.js tests/codex-provider.test.js tests/gatewayAgent.test.js",
     "test:smoke": "node --test tests/smoke.test.js",
     "test:auth": "node --test tests/auth.test.js",
     "test": "node --test tests/smoke.test.js tests/auth.test.js"

--- a/src/agents/gatewayAgent.js
+++ b/src/agents/gatewayAgent.js
@@ -81,8 +81,10 @@ export function streamProvider({ provider, messages, model, systemPrompt, agentI
       let fullText = ''
       let usage = null
       let buffer = ''
+      let sawDone = false
+      let stopReading = false
 
-      while (true) {
+      while (!stopReading) {
         const { done, value } = await reader.read()
         if (done) break
 
@@ -101,13 +103,18 @@ export function streamProvider({ provider, messages, model, systemPrompt, agentI
             }
             if (json.type === 'usage') usage = json.usage
             if (json.type === 'error') throw new Error(json.message)
-            if (json.type === 'done') break
+            if (json.type === 'done') {
+              sawDone = true
+              stopReading = true
+              break
+            }
           } catch (e) {
             if (e.message !== 'Unexpected end of JSON input') throw e
           }
         }
       }
 
+      if (!sawDone) throw new Error('Stream terminated without explicit done event')
       onDone?.(fullText, usage)
     } catch (err) {
       if (err.name !== 'AbortError') onError?.(err)

--- a/tests/codex-provider.test.js
+++ b/tests/codex-provider.test.js
@@ -1,0 +1,34 @@
+import { afterEach, it } from 'node:test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const originalExe = process.env.CODEX_EXE_PATH
+
+function importFresh(modulePath) {
+  const url = pathToFileURL(path.resolve(modulePath)).href
+  return import(`${url}?t=${Date.now()}-${Math.random()}`)
+}
+
+afterEach(() => {
+  if (originalExe === undefined) delete process.env.CODEX_EXE_PATH
+  else process.env.CODEX_EXE_PATH = originalExe
+})
+
+it('treats non-zero codex process exit as an error instead of success', async () => {
+  process.env.CODEX_EXE_PATH = process.execPath
+
+  const { stream } = await importFresh('./bridge/providers/codex.js')
+  const events = []
+
+  for await (const event of stream({
+    messages: [{ role: 'user', content: 'hello' }],
+    model: 'gpt-5.4',
+  })) {
+    events.push(event)
+  }
+
+  assert.deepEqual(events, [
+    { type: 'error', message: 'codex CLI exited with code 1' },
+  ])
+})

--- a/tests/gatewayAgent.test.js
+++ b/tests/gatewayAgent.test.js
@@ -1,0 +1,103 @@
+import { it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+function importFresh(modulePath) {
+  const url = pathToFileURL(path.resolve(modulePath)).href
+  return import(`${url}?t=${Date.now()}-${Math.random()}`)
+}
+
+async function importGatewayAgentForNode() {
+  const sourcePath = path.resolve('./src/agents/gatewayAgent.js')
+  const source = await fs.readFile(sourcePath, 'utf8')
+  const patched = source.replace(
+    "const BRIDGE = import.meta.env.VITE_CODEX_BRIDGE_URL || 'http://localhost:4891'",
+    "const BRIDGE = 'http://localhost:4891'"
+  )
+  return import(`data:text/javascript;base64,${Buffer.from(patched).toString('base64')}`)
+}
+
+function makeStreamResponse(chunks) {
+  let idx = 0
+  return {
+    ok: true,
+    body: {
+      getReader() {
+        return {
+          async read() {
+            if (idx >= chunks.length) return { done: true, value: undefined }
+            return { done: false, value: new TextEncoder().encode(chunks[idx++]) }
+          },
+        }
+      },
+    },
+  }
+}
+
+it('does not call onDone when the stream closes without an explicit done event', async () => {
+  const fetchCalls = []
+  global.fetch = async (url) => {
+    fetchCalls.push(String(url))
+    if (String(url).endsWith('/token')) {
+      return {
+        json: async () => ({ token: 'local-token' }),
+      }
+    }
+    return makeStreamResponse([
+      'data: {"type":"chunk","text":"hello"}\n\n',
+    ])
+  }
+
+  const { streamProvider } = await importGatewayAgentForNode()
+
+  const result = await new Promise((resolve) => {
+    streamProvider({
+      provider: 'claudecode',
+      messages: [{ role: 'user', content: 'hello' }],
+      model: 'claude-sonnet-4-6',
+      onChunk: () => {},
+      onDone: (fullText) => resolve({ kind: 'done', fullText }),
+      onError: (err) => resolve({ kind: 'error', message: err.message }),
+    })
+  })
+
+  assert.deepEqual(fetchCalls.length, 2)
+  assert.deepEqual(result, {
+    kind: 'error',
+    message: 'Stream terminated without explicit done event',
+  })
+})
+
+it('calls onDone when an explicit done event is received', async () => {
+  global.fetch = async (url) => {
+    if (String(url).endsWith('/token')) {
+      return {
+        json: async () => ({ token: 'local-token' }),
+      }
+    }
+    return makeStreamResponse([
+      'data: {"type":"chunk","text":"hello"}\n\n',
+      'data: {"type":"done"}\n\n',
+    ])
+  }
+
+  const { streamProvider } = await importGatewayAgentForNode()
+
+  const result = await new Promise((resolve) => {
+    streamProvider({
+      provider: 'claudecode',
+      messages: [{ role: 'user', content: 'hello' }],
+      model: 'claude-sonnet-4-6',
+      onChunk: () => {},
+      onDone: (fullText) => resolve({ kind: 'done', fullText }),
+      onError: (err) => resolve({ kind: 'error', message: err.message }),
+    })
+  })
+
+  assert.deepEqual(result, {
+    kind: 'done',
+    fullText: 'hello',
+  })
+})

--- a/tests/policy.test.js
+++ b/tests/policy.test.js
@@ -53,3 +53,36 @@ it('emits an explicit error when a provider stream closes without a done event',
     { type: 'error', message: 'Stream terminated without explicit done event' },
   ])
 })
+
+it('forwards the client abort signal to the provider and exits cleanly on abort', async () => {
+  const { withPolicy } = await importFresh('./bridge/policy.js')
+  const ac = new AbortController()
+  const events = []
+
+  let sawSameSignal = false
+  let providerSawAbort = false
+  let releaseAbort
+  const waitForAbort = new Promise(resolve => { releaseAbort = resolve })
+
+  async function* abortAwareStream({ signal }) {
+    sawSameSignal = signal === ac.signal
+    signal?.addEventListener('abort', () => {
+      providerSawAbort = true
+      releaseAbort()
+    }, { once: true })
+
+    yield { type: 'chunk', text: 'partial' }
+    await waitForAbort
+  }
+
+  for await (const event of withPolicy('demo', abortAwareStream, { model: 'demo-model', signal: ac.signal })) {
+    events.push(event)
+    if (event.type === 'chunk') ac.abort()
+  }
+
+  assert.equal(sawSameSignal, true)
+  assert.equal(providerSawAbort, true)
+  assert.deepEqual(events, [
+    { type: 'chunk', text: 'partial' },
+  ])
+})

--- a/tests/policy.test.js
+++ b/tests/policy.test.js
@@ -1,0 +1,55 @@
+import { it } from 'node:test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+function importFresh(modulePath) {
+  const url = pathToFileURL(path.resolve(modulePath)).href
+  return import(`${url}?t=${Date.now()}-${Math.random()}`)
+}
+
+it('does not emit a timeout error solely because total stream lifetime exceeds the old gateway wall-clock limit', async () => {
+  const prevTimeout = process.env.GATEWAY_TIMEOUT_MS
+  process.env.GATEWAY_TIMEOUT_MS = '50'
+
+  try {
+    const { withPolicy } = await importFresh('./bridge/policy.js')
+    const events = []
+
+    async function* slowButHealthyStream() {
+      yield { type: 'chunk', text: 'partial' }
+      await new Promise(resolve => setTimeout(resolve, 100))
+      yield { type: 'done' }
+    }
+
+    for await (const event of withPolicy('demo', slowButHealthyStream, { model: 'demo-model' })) {
+      events.push(event)
+    }
+
+    assert.deepEqual(events, [
+      { type: 'chunk', text: 'partial' },
+      { type: 'done' },
+    ])
+  } finally {
+    if (prevTimeout === undefined) delete process.env.GATEWAY_TIMEOUT_MS
+    else process.env.GATEWAY_TIMEOUT_MS = prevTimeout
+  }
+})
+
+it('emits an explicit error when a provider stream closes without a done event', async () => {
+  const { withPolicy } = await importFresh('./bridge/policy.js')
+  const events = []
+
+  async function* truncatedStream() {
+    yield { type: 'chunk', text: 'partial' }
+  }
+
+  for await (const event of withPolicy('demo', truncatedStream, { model: 'demo-model' })) {
+    events.push(event)
+  }
+
+  assert.deepEqual(events, [
+    { type: 'chunk', text: 'partial' },
+    { type: 'error', message: 'Stream terminated without explicit done event' },
+  ])
+})


### PR DESCRIPTION
## What changed

This PR removes gateway-level wall-clock timeout semantics for streaming requests and tightens completion/error handling so a request is only considered successful when an explicit `done` event is observed.

### Change set

1. `bridge/policy.js`
   - removed the fixed gateway-wide stream timeout branch
   - kept concurrency limiting, client-abort propagation, and yielded-error handling
   - added explicit `Stream terminated without explicit done event` failure when a provider closes without `done`
2. `bridge/providers/codex.js`
   - treat `exit code === 0` as success
   - map non-zero process exit to `error` instead of `done`
3. `src/agents/gatewayAgent.js`
   - require explicit `done` before calling `onDone`
   - surface EOF-without-done as an error to the UI
4. Added regression tests for:
   - long-running stream no longer timing out solely on total elapsed wall-clock time
   - provider stream closure without `done` now becomes an explicit error
   - codex non-zero exit is treated as an error
   - frontend EOF-without-done is not treated as success
5. Added `npm run test:stream` for the new stream-semantics regression suite
6. Added implementation plan archive under `docs/plans/2026-03-20-issue-45-streaming-timeout-semantics.md`

## Why it changed

Issue #45 identified two coupled problems in the current stream pipeline:

- the gateway policy layer enforced a fixed 60s wall-clock timeout across the full stream lifetime, which could terminate healthy long-running/tool-calling flows
- success semantics were too loose across provider/frontend boundaries, so abnormal termination could be mistaken for a normal completion

This PR keeps the gateway thin on business-failure semantics and makes success depend on an explicit terminal `done` signal.

## What was not changed

- Claude provider auth/configuration behavior was not changed
- retry policy for yielded provider errors before any chunks were emitted was not changed
- smoke test definitions were not changed
- no README/CLAUDE docs were updated in this PR

## Risks

- Providers that currently rely on implicit EOF as a success signal will now surface `Stream terminated without explicit done event`; this is intentional, but it raises the contract bar for adapters
- removing the gateway wall-clock timeout shifts timeout/failure authority fully to provider/native transport paths, so provider adapters need to keep explicit terminal signaling correct
- built-in Claude smoke still depends on the local CLI login state of the environment running validation

## Validation

- `npm run test:stream` ✅
  - policy: no gateway wall-clock timeout on healthy long stream
  - policy: EOF-without-done becomes explicit error
  - codex: non-zero exit becomes error
  - frontend: EOF-without-done no longer calls `onDone`
  - frontend: explicit `done` still completes successfully
- `npm run test:auth` ✅
- `npm run build` ✅
- `npm run test:smoke` ⚠️ partial
  - Claude built-in smoke failed in this environment: `Not logged in · Please run /login`
  - Codex built-in smoke passed

## Docs impact

Docs impact: none

Docs were reviewed for this change; no setup/onboarding/user-facing documentation was updated because the PR only tightens internal stream completion semantics and does not change configuration or operator workflow.

## Linked issue

Closes #45
